### PR TITLE
Document how to disable backtraces

### DIFF
--- a/failure-1.X/src/lib.rs
+++ b/failure-1.X/src/lib.rs
@@ -12,6 +12,14 @@
 //! deal with the `Error` type. There are exceptions to this rule, though, in
 //! both directions, and users should do whatever seems most appropriate to
 //! their situation.
+//!
+//! ## Backtraces
+//!
+//! Backtraces are disabled by default. To turn backtraces on, enable
+//! the `backtrace` Cargo feature and set the `RUST_BACKTRACE` environment
+//! variable to a non-zero value (this also enables backtraces for panics).
+//! Use the `RUST_FAILURE_BACKTRACE` variable to enable or disable backtraces
+//! for `failure` specifically.
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![cfg_attr(feature = "small-error", feature(extern_types, allocator_api))]


### PR DESCRIPTION
This serves two purposes:

- documenting that failure has backtraces (an absence of which is a commonly cited drawback of `StdError`).
- document how to enable/disable them.

There are several `.backtrace` methods, so I decided to just put this info in the root module 😆 