### PR TITLE
Add Error::from_std method

### DIFF
--- a/failure-1.X/src/box_std.rs
+++ b/failure-1.X/src/box_std.rs
@@ -1,0 +1,19 @@
+use Fail;
+use std::error::Error;
+use std::fmt::{self, Debug, Display};
+
+pub(crate) struct BoxStd(pub(crate) Box<Error + Send + Sync + 'static>);
+
+impl Display for BoxStd {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Debug for BoxStd {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl Fail for BoxStd {}

--- a/failure-1.X/src/lib.rs
+++ b/failure-1.X/src/lib.rs
@@ -56,6 +56,8 @@ with_std! {
     mod sync_failure;
     pub use sync_failure::SyncFailure;
 
+    mod box_std;
+
     #[cfg_attr(feature = "small-error", path = "./small_error.rs")]
     mod error;
 

--- a/failure-1.X/src/small_error.rs
+++ b/failure-1.X/src/small_error.rs
@@ -3,11 +3,13 @@ use std::heap::{Heap, Alloc, Layout};
 
 use core::mem;
 use core::ptr;
+use std::error::Error as StdError;
 
 use {Causes, Fail};
 use backtrace::Backtrace;
 use context::Context;
 use compat::Compat;
+use box_std::BoxStd;
 
 /// The `Error` type, which can contain any failure.
 ///
@@ -56,7 +58,7 @@ struct TraitObject {
 
 impl<F: Fail> From<F> for Error {
     fn from(failure: F) -> Error {
-        unsafe { 
+        unsafe {
             let ptr: *mut InnerRaw<F> = match Heap.alloc(Layout::new::<InnerRaw<F>>()) {
                 Ok(p)   => p as *mut InnerRaw<F>,
                 Err(e)  => Heap.oom(e),
@@ -102,6 +104,30 @@ impl Inner {
 }
 
 impl Error {
+    /// Creates an `Error` from `Box<std::error::Error>`.
+    ///
+    /// This method is useful for comparability with code,
+    /// which does not use the `Fail` trait.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::error::Error as StdError;
+    /// use failure::Error;
+    ///
+    /// fn app_fn() -> Result<i32, Error> {
+    ///     let x = library_fn().map_err(Error::from_compat)?;
+    ///     Ok(x * 2)
+    /// }
+    ///
+    /// fn library_fn() -> Result<i32, Box<StdError + Sync + Send + 'static>> {
+    ///     Ok(92)
+    /// }
+    /// ```
+    pub fn from_compat(err: Box<StdError + Sync + Send + 'static>) -> Error {
+        Error::from(BoxStd(err))
+    }
+
     /// Returns a reference to the underlying cause of this `Error`. Unlike the
     /// method on `Fail`, this does not return an `Option`. The `Error` type
     /// always has an underlying failure.


### PR DESCRIPTION
This method allows to convert from Box<std::error::Error> to Error.
Conversion in the opposite direction could be achieved with the `Compat`
struct

closes #158

Couple of questions:

- should we add `from_std_sync` for `Box<std::error::Error + Send + !Sync>`?
- is there a better name for this method?