### PR TITLE
Context pretty-printing helper

### DIFF
--- a/failure-1.X/src/error.rs
+++ b/failure-1.X/src/error.rs
@@ -3,7 +3,7 @@ use core::fmt::{self, Display, Debug};
 use core::mem;
 use core::ptr;
 
-use {Causes, Fail};
+use {Causes, Fail, PrettyFail};
 use backtrace::Backtrace;
 use context::Context;
 use compat::Compat;
@@ -135,6 +135,10 @@ impl Error {
     pub fn causes(&self) -> Causes {
         Causes { fail: Some(self.cause()) }
     }
+
+    /// Returns an implementer of `Display` that displays the `Error` and all
+    /// its causes delimited by the string ": ".
+    pub fn pretty(&self) -> PrettyFail { PrettyFail(self.cause()) }
 }
 
 impl Display for Error {


### PR DESCRIPTION
Good for printing messages like `couldn't open "./foo.bar": no such file or directory`. I find myself copy-pasting this into nearly every single utility I write, and I doubt I'm the only one. It's considerably less awkward implemented first-party, and awfully small for an external crate. Exact naming subject to bikeshedding.

I'm not really sure what's going on with the `Sized` constraint or the inherent impl on the trait object, so please sanity-check.