### PR TITLE
added documentation for bail and ensure

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [failure](./intro.md)
 - [How to use failure](./howto.md)
+	- [bail! and ensure!](./bail-and-ensure.md)
     - [The Fail trait](./fail.md)
     - [Deriving Fail](./derive-fail.md)
     - [The Error type](./error.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,10 +2,10 @@
 
 - [failure](./intro.md)
 - [How to use failure](./howto.md)
-	- [bail! and ensure!](./bail-and-ensure.md)
     - [The Fail trait](./fail.md)
     - [Deriving Fail](./derive-fail.md)
     - [The Error type](./error.md)
+    - [`bail!` and `ensure!`](./bail-and-ensure.md)
 - [Patterns & Guidance](./guidance.md)
     - [Strings as errors](./error-msg.md)
     - [A Custom Fail type](./custom-fail.md)

--- a/book/src/bail-and-ensure.md
+++ b/book/src/bail-and-ensure.md
@@ -1,10 +1,10 @@
-# bail! and ensure!
+# `bail!` and `ensure!`
 
-If you were a fan of the bail! and ensure! macros from error-chain, good news. failure has a version of these macros as well.
+If you were a fan of the `bail!` and ensure! macros from error-chain, good news. failure has a version of these macros as well.
 
-The bail! macro returns an error immediately, based on a format string. The ensure! macro additionally takes a conditional, and returns the error only if that conditional is false. You can think of bail! and ensure! as being analogous to panic! and assert!, but throwing errors instead of panicking.
+The `bail!` macro returns an error immediately, based on a format string. The `ensure!` macro additionally takes a conditional, and returns the error only if that conditional is false. You can think of `bail!` and `ensure!` as being analogous to `panic!` and `assert!`, but throwing errors instead of panicking.
 
-Bail and ensure macros are useful when you are prototyping and you want to write your custom errors later. It is also the simplest example of using the failure crate.
+`bail!` and `ensure!` macros are useful when you are prototyping and you want to write your custom errors later. It is also the simplest example of using the failure crate.
 
 ## Example
 ```rust

--- a/book/src/bail-and-ensure.md
+++ b/book/src/bail-and-ensure.md
@@ -1,0 +1,18 @@
+# bail! and ensure!
+
+If you were a fan of the bail! and ensure! macros from error-chain, good news. failure has a version of these macros as well.
+
+The bail! macro returns an error immediately, based on a format string. The ensure! macro additionally takes a conditional, and returns the error only if that conditional is false. You can think of bail! and ensure! as being analogous to panic! and assert!, but throwing errors instead of panicking.
+
+Bail and ensure macros are useful when you are prototyping and you want to write your custom errors later. It is also the simplest example of using the failure crate.
+
+## Example
+```rust
+#[macro_use] extern crate failure;
+
+fn safe_cast_to_unsigned(n:i32) -> Result<u32, error::Failure>
+{
+    ensure!(n>=0, "number cannot be smaller than 0!");
+    (u32) n
+}
+```


### PR DESCRIPTION
I noticed that documentation on bail and ensure macros is missing so I added it.
It is very easy pattern and good for prototyping so I added it to the beginning of the docs.