### PR TITLE
Implement flat error mapping

### DIFF
--- a/failure-1.X/failure_derive/src/lib.rs
+++ b/failure-1.X/failure_derive/src/lib.rs
@@ -4,13 +4,23 @@ extern crate proc_macro;
 #[macro_use] extern crate synstructure;
 #[macro_use] extern crate quote;
 
-decl_derive!([Fail, attributes(fail, cause)] => fail_derive);
+decl_derive!([Fail, attributes(fail, cause, flat_cause)] => fail_derive);
 
 fn fail_derive(s: synstructure::Structure) -> quote::Tokens {
     let cause_body = s.each_variant(|v| {
-        if let Some(cause) = v.bindings().iter().find(is_cause) {
-            quote!(return Some(#cause))
+        if let Some(cause) = v.bindings().iter().find(|&x| is_cause(&x).is_some()) {
+            match is_cause(&cause) {
+                // Normal cause field; just return the field.
+                Some(CauseType::Normal) => quote!(return Some(#cause)),
+
+                // The field is an Error wrapping the actual cause; forward the error's cause.
+                Some(CauseType::FlatMap) => quote!(return Some(#cause.cause())),
+
+                // ???
+                None => unreachable!()
+            }
         } else {
+            // No cause field.
             quote!(return None)
         }
     });
@@ -67,16 +77,35 @@ fn is_backtrace(bi: &&synstructure::BindingInfo) -> bool {
         }
 }
 
-fn is_cause(bi: &&synstructure::BindingInfo) -> bool {
-    let mut found_cause = false;
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+enum CauseType {
+    Normal,
+    FlatMap
+}
+
+fn is_cause(bi: &&synstructure::BindingInfo) -> Option<CauseType> {
+    let mut found_cause = None;
     for attr in &bi.ast().attrs {
         if attr.path == parse_quote!(fail) {
             if let Some(syn::Meta::List(ref list)) = attr.interpret_meta() {
                 if let Some(pair) = list.nested.first() {
                     if let &syn::NestedMeta::Meta(syn::Meta::Word(ref word)) = pair.into_value() {
                         if word == "cause" {
-                            if found_cause { panic!("Cannot have two `cause` attributes"); }
-                            found_cause = true;
+                            match found_cause { 
+                                Some(CauseType::Normal) => panic!("Cannot have two `cause` attributes"),
+                                Some(CauseType::FlatMap) => panic!("Cannot have both `cause` and `flat_cause` attributes"),
+                                None => ()
+                            }
+
+                            found_cause = Some(CauseType::Normal);
+                        } else if word == "flat_cause" {
+                            match found_cause {
+                                Some(CauseType::Normal) => panic!("Cannot have both `cause` and `flat_cause` attributes"),
+                                Some(CauseType::FlatMap) => panic!("Cannot have two `flat_cause` attributes"),
+                                None => ()
+                            }
+                            
+                            found_cause = Some(CauseType::FlatMap)
                         }
                     }
                 }

--- a/failure-1.X/failure_derive/tests/wraps.rs
+++ b/failure-1.X/failure_derive/tests/wraps.rs
@@ -68,3 +68,23 @@ fn wrap_enum_error() {
     assert!(err.cause().and_then(|err| err.downcast_ref::<fmt::Error>()).is_some());
     assert!(err.backtrace().is_some());
 }
+
+#[derive(Fail, Debug, Display)]
+#[display(fmt = "An error has occured.")]
+struct WrapFailureError {
+    #[fail(flat_cause)] inner: failure::Error
+}
+
+#[derive(Fail, Debug, Display)]
+#[display(fmt = "Unit error.")]
+struct UnitError;
+
+#[test]
+fn wrap_failure_error() {
+    let inner: failure::Error  = UnitError.into();
+    let err = WrapFailureError { inner };
+    assert!(err.cause().and_then(|err| err.downcast_ref::<UnitError>()).is_some());
+    assert!(err.backtrace().is_none());
+}
+
+


### PR DESCRIPTION
The most natural way to chain errors in the failure crate is to
have failures that contain other `Error`s. This is supported in the
`derive(Fail)` macro using `fail(cause)`. However, confusingly, this
doesn't work for `failure::Error`!

This PR adds a new directive, `flat_cause`, that acts as a flat map,
taking the underlying Fail out of a `failure::Error`.

As an added bonus, it works with any type that implements
`cause(&self) -> &Fail`.