### PR TITLE
Disable the small-error feature.

### DIFF
--- a/failure-1.X/Cargo.toml
+++ b/failure-1.X/Cargo.toml
@@ -23,6 +23,6 @@ version = "0.3.3"
 
 [features]
 default = ["std", "derive"]
-small-error = ["std"]
+#small-error = ["std"]
 std = []
 derive = ["failure_derive", "display_derive"]

--- a/travis.sh
+++ b/travis.sh
@@ -23,7 +23,7 @@ test_derive_in() {
 
 test_nightly_features_in() {
   cd $1
-  cargo_test --features small-error
+  #cargo_test --features small-error
   cargo_test --all-features
   cd $DIR
 }


### PR DESCRIPTION
The small error feature was buggy (#180) and built on top of the allocator API which is experiencing churn, causing the build to break on nightly (#203). Disabling the feature for now.

Closes #202.
Fixes #203.