### PR TITLE
Added support for dereferencing the Compat type

### DIFF
--- a/failure-1.X/src/compat.rs
+++ b/failure-1.X/src/compat.rs
@@ -20,6 +20,11 @@ impl<E> Compat<E> {
     pub fn into_inner(self) -> E {
         self.error
     }
+
+    /// Gets a reference to the inner error.
+    pub fn get_ref(&self) -> &E {
+        &self.error
+    }
 }
 
 with_std! {


### PR DESCRIPTION
It's already possible to convert a `Compat<E>` into `E` but for uses with `downcast_ref` (in particular where `compat()` is called in a chain on something) it's useful to be able to get a reference to the contained error. I ran across this when working with actix-web which uses failure compat heavily for interoperability.