### PR TITLE
Avoid std dependencies in no_std environments

### DIFF
--- a/failure-0.1.X/Cargo.toml
+++ b/failure-0.1.X/Cargo.toml
@@ -17,11 +17,12 @@ default-features = false
 optional = true
 version = "0.1.2"
 path = "./failure_derive"
+default-features = false
 
 [features]
 default = ["std", "derive"]
 backtrace = ["failure_compat_shim/backtrace"]
-std = ["backtrace", "failure_compat_shim/std"]
+std = ["backtrace", "failure_compat_shim/std", "failure_derive/std"]
 derive = ["failure_derive", "failure_compat_shim/derive"]
 
 [[example]]

--- a/failure-1.X/Cargo.toml
+++ b/failure-1.X/Cargo.toml
@@ -12,10 +12,12 @@ version = "1.0.0"
 optional = true
 version = "1.0.0"
 path = "./failure_derive"
+default-features = false
 
 [dependencies.display_derive]
 optional = true
 git = "https://github.com/withoutboats/display_derive"
+default-features = false
 
 [dependencies.backtrace]
 optional = true
@@ -24,5 +26,5 @@ version = "0.3.3"
 [features]
 default = ["std", "derive"]
 #small-error = ["std"]
-std = []
+std = ["failure_derive/std", "display_derive/std"]
 derive = ["failure_derive", "display_derive"]


### PR DESCRIPTION
When built without the std feature, failure does not pass this setting on to failure_derive and display_derive. This causes implicit dependencies on the std crate.

Dependent on https://github.com/withoutboats/display_derive/pull/8 for full effect, as display_derive has its own no_std incompatibilities.
Fixes #214.