### PR TITLE
Update some URLs to refer to rust-lang-nursery repo

### DIFF
--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -5,11 +5,9 @@ creating and managing errors in Rust. Additional documentation is found here:
 
 * [API documentation][api]
 * [failure source code][repo]
-* [failure_derive source code][derive-repo]
 
 [api]: https://boats.gitlab.io/failure/doc/failure
-[repo]: https://github.com/withoutboats/failure
-[derive-repo]: https://github.com/withoutboats/failure_derive
+[repo]: https://github.com/rust-lang-nursery/failure
 
 ```rust
 extern crate serde;

--- a/failure-1.X/Cargo.toml
+++ b/failure-1.X/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://docs.rs/failure"
 homepage = "https://boats.gitlab.io/failure"
 license = "MIT OR Apache-2.0"
 name = "failure"
-repository = "https://github.com/withoutboats/failure"
+repository = "https://github.com/rust-lang-nursery/failure"
 version = "1.0.0"
 
 [dependencies.failure_derive]

--- a/failure-1.X/failure_derive/Cargo.toml
+++ b/failure-1.X/failure_derive/Cargo.toml
@@ -3,7 +3,6 @@ authors = ["Without Boats <woboats@gmail.com>"]
 description = "derives for the failure crate"
 license = "MIT OR Apache-2.0"
 name = "failure_derive"
-repository = "https://github.com/withoutboats/failure_derive"
 homepage = "https://boats.gitlab.io/failure"
 documentation = "https://boats.gitlab.io/failure"
 version = "1.0.0"


### PR DESCRIPTION
Resolves: #190.