### PR TITLE
Fix #[derive(Fail)] when mixing no_std and std crates

### DIFF
--- a/failure_derive/Cargo.toml
+++ b/failure_derive/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro2 = "0.4.8"
 
 [dev-dependencies.failure]
 version = "0.1.0"
+path = ".."
 
 [dev-dependencies.display_derive]
 git = "https://github.com/withoutboats/display_derive"

--- a/failure_derive/Cargo.toml
+++ b/failure_derive/Cargo.toml
@@ -24,5 +24,5 @@ git = "https://github.com/withoutboats/display_derive"
 proc-macro = true
 
 [features]
-default = ["std"]
+# This is kept for backward-compatibility reasons, but is otherwise a no-op
 std = []

--- a/failure_derive/src/lib.rs
+++ b/failure_derive/src/lib.rs
@@ -25,59 +25,27 @@ fn fail_derive(s: synstructure::Structure) -> TokenStream {
         }
     });
 
-    #[cfg(feature = "std")]
     let fail = s.gen_impl(quote! {
         gen impl ::failure::Fail for @Self {
             #[allow(unreachable_code)]
-            fn cause(&self) -> ::std::option::Option<&::failure::Fail> {
+            fn cause(&self) -> ::failure::_core::option::Option<&::failure::Fail> {
                 match *self { #cause_body }
                 None
             }
 
             #[allow(unreachable_code)]
-            fn backtrace(&self) -> ::std::option::Option<&::failure::Backtrace> {
+            fn backtrace(&self) -> ::failure::_core::option::Option<&::failure::Backtrace> {
                 match *self { #bt_body }
                 None
             }
         }
     });
 
-    #[cfg(not(feature = "std"))]
-    let fail = s.gen_impl(quote! {
-        gen impl ::failure::Fail for @Self {
-            #[allow(unreachable_code)]
-            fn cause(&self) -> ::core::option::Option<&::failure::Fail> {
-                match *self { #cause_body }
-                None
-            }
-
-            #[allow(unreachable_code)]
-            fn backtrace(&self) -> ::core::option::Option<&::failure::Backtrace> {
-                match *self { #bt_body }
-                None
-            }
-        }
-    });
-
-    #[cfg(feature = "std")]
     let display = display_body(&s).map(|display_body| {
         s.gen_impl(quote! {
-            gen impl ::std::fmt::Display for @Self {
+            gen impl ::failure::_core::fmt::Display for @Self {
                 #[allow(unreachable_code)]
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                    match *self { #display_body }
-                    write!(f, "An error has occurred.")
-                }
-            }
-        })
-    });
-
-    #[cfg(not(feature = "std"))]
-    let display = display_body(&s).map(|display_body| {
-        s.gen_impl(quote! {
-            gen impl ::core::fmt::Display for @Self {
-                #[allow(unreachable_code)]
-                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                fn fmt(&self, f: &mut ::failure::_core::fmt::Formatter) -> ::failure::_core::fmt::Result {
                     match *self { #display_body }
                     write!(f, "An error has occurred.")
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,11 @@
 macro_rules! with_std { ($($i:item)*) => ($(#[cfg(feature = "std")]$i)*) }
 macro_rules! without_std { ($($i:item)*) => ($(#[cfg(not(feature = "std"))]$i)*) }
 
+// Re-export libcore using an alias so that the macros can work without
+// requiring `extern crate core` downstream.
+#[doc(hidden)]
+pub extern crate core as _core;
+
 mod backtrace;
 mod compat;
 mod context;


### PR DESCRIPTION
Fixes #214