### PR TITLE
Update syn/quote/synstructure dependencies in 0.1

### DIFF
--- a/failure-0.1.X/failure_derive/Cargo.toml
+++ b/failure-0.1.X/failure_derive/Cargo.toml
@@ -9,9 +9,10 @@ documentation = "https://boats.gitlab.io/failure"
 version = "0.1.2"
 
 [dependencies]
-quote = "0.3.15"
-syn = "0.11.11"
-synstructure = "0.6.0"
+quote = "0.6.3"
+syn = "0.14.4"
+synstructure = "0.9.0"
+proc-macro2 = "0.4.8"
 
 [dev-dependencies.failure]
 version = "0.1.0"

--- a/failure-0.1.X/failure_derive/src/lib.rs
+++ b/failure-0.1.X/failure_derive/src/lib.rs
@@ -1,14 +1,15 @@
-extern crate proc_macro;
+extern crate proc_macro2;
 extern crate syn;
 
 #[macro_use] extern crate synstructure;
 #[macro_use] extern crate quote;
 
 use std::io::{self, Write};
+use proc_macro2::TokenStream;
 
 decl_derive!([Fail, attributes(fail, cause)] => fail_derive);
 
-fn fail_derive(s: synstructure::Structure) -> quote::Tokens {
+fn fail_derive(s: synstructure::Structure) -> TokenStream {
     let cause_body = s.each_variant(|v| {
         if let Some(cause) = v.bindings().iter().find(is_cause) {
             quote!(return Some(#cause))
@@ -26,87 +27,96 @@ fn fail_derive(s: synstructure::Structure) -> quote::Tokens {
     });
 
     #[cfg(feature = "std")]
-    let fail = s.bound_impl("::failure::Fail", quote! {
-        #[allow(unreachable_code)]
-        fn cause(&self) -> ::std::option::Option<&::failure::Fail> {
-            match *self { #cause_body }
-            None
-        }
+    let fail = s.gen_impl(quote! {
+        gen impl ::failure::Fail for @Self {
+            #[allow(unreachable_code)]
+            fn cause(&self) -> ::std::option::Option<&::failure::Fail> {
+                match *self { #cause_body }
+                None
+            }
 
-        #[allow(unreachable_code)]
-        fn backtrace(&self) -> ::std::option::Option<&::failure::Backtrace> {
-            match *self { #bt_body }
-            None
+            #[allow(unreachable_code)]
+            fn backtrace(&self) -> ::std::option::Option<&::failure::Backtrace> {
+                match *self { #bt_body }
+                None
+            }
         }
     });
 
     #[cfg(not(feature = "std"))]
-    let fail = s.bound_impl("::failure::Fail", quote! {
-        #[allow(unreachable_code)]
-        fn cause(&self) -> ::core::option::Option<&::failure::Fail> {
-            match *self { #cause_body }
-            None
-        }
+    let fail = s.gen_impl(quote! {
+        gen impl ::failure::Fail for @Self {
+            #[allow(unreachable_code)]
+            fn cause(&self) -> ::core::option::Option<&::failure::Fail> {
+                match *self { #cause_body }
+                None
+            }
 
-        #[allow(unreachable_code)]
-        fn backtrace(&self) -> ::core::option::Option<&::failure::Backtrace> {
-            match *self { #bt_body }
-            None
+            #[allow(unreachable_code)]
+            fn backtrace(&self) -> ::core::option::Option<&::failure::Backtrace> {
+                match *self { #bt_body }
+                None
+            }
         }
     });
 
     #[cfg(feature = "std")]
     let display = display_body(&s).map(|display_body| {
-        s.bound_impl("::std::fmt::Display", quote! {
-            #[allow(unreachable_code)]
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                match *self { #display_body }
-                write!(f, "An error has occurred.")
+        s.gen_impl(quote! {
+            gen impl ::std::fmt::Display for @Self {
+                #[allow(unreachable_code)]
+                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    match *self { #display_body }
+                    write!(f, "An error has occurred.")
+                }
             }
         })
     });
 
     #[cfg(not(feature = "std"))]
     let display = display_body(&s).map(|display_body| {
-        s.bound_impl("::core::fmt::Display", quote! {
-            #[allow(unreachable_code)]
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                match *self { #display_body }
-                write!(f, "An error has occurred.")
+        s.gen_impl(quote! {
+            gen impl ::core::fmt::Display for @Self {
+                #[allow(unreachable_code)]
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                    match *self { #display_body }
+                    write!(f, "An error has occurred.")
+                }
             }
         })
     });
 
-    quote! {
+    (quote! {
         #fail
         #display
-    }
+    }).into()
 }
 
-fn display_body(s: &synstructure::Structure) -> Option<quote::Tokens> {
+fn display_body(s: &synstructure::Structure) -> Option<quote::__rt::TokenStream> {
     let mut msgs = s.variants().iter().map(|v| find_error_msg(&v.ast().attrs));
     if msgs.all(|msg| msg.is_none()) { return None; }
 
     Some(s.each_variant(|v| {
         let msg = find_error_msg(&v.ast().attrs).expect("All variants must have display attribute.");
-        if msg.is_empty() {
+        if msg.nested.is_empty() {
             panic!("Expected at least one argument to fail attribute");
         }
 
-        let s = match msg[0] {
-            syn::NestedMetaItem::MetaItem(syn::MetaItem::NameValue(ref i, ref lit)) if i == "display" => {
-                lit.clone()
+        let s = match msg.nested[0] {
+            syn::NestedMeta::Meta(syn::Meta::NameValue(ref nv)) if nv.ident == "display" => {
+                nv.lit.clone()
             }
             _ => panic!("Fail attribute must begin `display = \"\"` to control the Display message."),
         };
-        let args = msg[1..].iter().map(|arg| match *arg {
-            syn::NestedMetaItem::Literal(syn::Lit::Int(i, _)) => {
-                let bi = &v.bindings()[i as usize];
+        let args = msg.nested.iter().skip(1).map(|arg| match *arg {
+            syn::NestedMeta::Literal(syn::Lit::Int(ref i)) => {
+                let bi = &v.bindings()[i.value() as usize];
                 quote!(#bi)
             }
-            syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref id)) => {
-                if id.as_ref().starts_with("_") {
-                    if let Ok(idx) = id.as_ref()[1..].parse::<usize>() {
+            syn::NestedMeta::Meta(syn::Meta::Word(ref id)) => {
+                let id_s = id.to_string();
+                if id_s.starts_with("_") {
+                    if let Ok(idx) = id_s[1..].parse::<usize>() {
                         let bi = &v.bindings()[idx];
                         return quote!(#bi)
                     }
@@ -127,17 +137,19 @@ fn display_body(s: &synstructure::Structure) -> Option<quote::Tokens> {
     }))
 }
 
-fn find_error_msg(attrs: &[syn::Attribute]) -> Option<&[syn::NestedMetaItem]> {
+fn find_error_msg(attrs: &[syn::Attribute]) -> Option<syn::MetaList> {
     let mut error_msg = None;
     for attr in attrs {
-        if attr.name() == "fail" {
-            if error_msg.is_some() {
-                panic!("Cannot have two display attributes")
-            } else {
-                if let syn::MetaItem::List(_, ref list)  = attr.value {
-                    error_msg = Some(&list[..]);
+        if let Some(meta) = attr.interpret_meta() {
+            if meta.name() == "fail" {
+                if error_msg.is_some() {
+                    panic!("Cannot have two display attributes")
                 } else {
-                    panic!("fail attribute must take a list in parantheses")
+                    if let syn::Meta::List(list)  = meta {
+                        error_msg = Some(list);
+                    } else {
+                        panic!("fail attribute must take a list in parantheses")
+                    }
                 }
             }
         }
@@ -147,8 +159,13 @@ fn find_error_msg(attrs: &[syn::Attribute]) -> Option<&[syn::NestedMetaItem]> {
 
 fn is_backtrace(bi: &&synstructure::BindingInfo) -> bool {
         match bi.ast().ty {
-            syn::Ty::Path(None, syn::Path { segments: ref path, .. }) => {
-                path.last().map_or(false, |s| s.ident == "Backtrace" && s.parameters.is_empty())
+            syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: syn::Path { segments: ref path, .. }
+            }) => {
+                path.last().map_or(false, |s| {
+                    s.value().ident == "Backtrace" && s.value().arguments.is_empty()
+                })
             }
             _ => false
         }
@@ -157,20 +174,25 @@ fn is_backtrace(bi: &&synstructure::BindingInfo) -> bool {
 fn is_cause(bi: &&synstructure::BindingInfo) -> bool {
     let mut found_cause = false;
     for attr in &bi.ast().attrs {
-        if attr.name() == "cause" {
-            if found_cause { panic!("Cannot have two `cause` attributes"); }
-            writeln!(
-                io::stderr(),
-                "WARNING: failure's `#[cause]` attribute is deprecated. Use `#[fail(cause)]` instead."
-            ).unwrap();
-            found_cause = true;
-        }
-        if attr.name() == "fail" {
-            if let syn::MetaItem::List(_, ref list) = attr.value {
-                if let Some(&syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref word))) = list.get(0) {
-                    if word == "cause" {
-                        if found_cause { panic!("Cannot have two `cause` attributes"); }
-                        found_cause = true;
+        if let Some(meta) = attr.interpret_meta() {
+            if meta.name() == "cause" {
+                if found_cause { panic!("Cannot have two `cause` attributes"); }
+                writeln!(
+                    io::stderr(),
+                    "WARNING: failure's `#[cause]` attribute is deprecated. \
+                     Use `#[fail(cause)]` instead."
+                ).unwrap();
+                found_cause = true;
+            }
+            if meta.name() == "fail" {
+                if let syn::Meta::List(ref list) = meta {
+                    if let Some(ref pair) = list.nested.first() {
+                        if let &&syn::NestedMeta::Meta(syn::Meta::Word(ref word)) = pair.value() {
+                            if word == "cause" {
+                                if found_cause { panic!("Cannot have two `cause` attributes"); }
+                                found_cause = true;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This updates the dependencies of `failure_derive 0.1` (and thus `failure 0.1`).
Note that old dependencies are still pulled in due to withoutboats/display_derive#7.