### PR TITLE
Added support for rendering errors with causes

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,7 +16,5 @@ fn bad_function() -> Result<(), WrappingError> {
 }
 
 fn main() {
-    for cause in Fail::iter_causes(&bad_function().unwrap_err()) {
-        println!("{}", cause);
-    }
+    println!("{}", Fail::display(&bad_function().unwrap_err()));
 }

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -111,6 +111,11 @@ with_backtrace! {
             Backtrace { internal: InternalBacktrace::new() }
         }
 
+        /// Checks if the backtrace is empty.
+        pub fn is_empty(&self) -> bool {
+            self.internal.is_none()
+        }
+
         pub(crate) fn none() -> Backtrace {
             Backtrace { internal: InternalBacktrace::none() }
         }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,0 +1,43 @@
+use std::fmt;
+
+use Fail;
+use backtrace::Backtrace;
+
+
+/// Renders a fail with all causes.
+pub struct FailDisplay<'a>(pub(crate) &'a Fail, pub(crate) Option<&'a Backtrace>);
+
+impl<'a> fmt::Display for FailDisplay<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut ptr = Some(self.0);
+        let mut idx = 0;
+        let mut was_backtrace = false;
+
+        while let Some(fail) = ptr {
+            if was_backtrace {
+                write!(f, "\n")?;
+            }
+            was_backtrace = false;
+            if idx == 0 {
+                write!(f, "error: {}", fail)?;
+            } else {
+                write!(f, "\n  caused by: {}", fail)?;
+            }
+            if f.alternate() {
+                let backtrace = if idx == 0 && self.1.is_some() {
+                    Some(self.1.unwrap())
+                } else {
+                    fail.backtrace()
+                };
+                if let Some(backtrace) = backtrace {
+                    write!(f, "\nbacktrace:\n{}", backtrace)?;
+                    was_backtrace = true;
+                }
+            }
+            ptr = fail.cause();
+            idx += 1;
+        }
+
+        Ok(())
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -15,6 +15,8 @@ use self::error_impl::ErrorImpl;
 #[cfg(feature = "std")]
 use std::error::Error as StdError;
 
+use display::FailDisplay;
+
 
 /// The `Error` type, which can contain any failure.
 ///
@@ -153,6 +155,11 @@ impl Error {
     /// If the underlying error is not of type `T`, this will return `None`.
     pub fn downcast_mut<T: Fail>(&mut self) -> Option<&mut T> {
         self.imp.failure_mut().downcast_mut()
+    }
+
+    /// Displays the error.
+    pub fn display(&self) -> FailDisplay {
+        FailDisplay(self.as_fail(), Some(self.backtrace()))
     }
 
     /// Deprecated alias to `find_root_cause`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod box_std;
 mod compat;
 mod context;
 mod result_ext;
+mod display;
 
 use core::any::TypeId;
 use core::fmt::{Debug, Display};
@@ -47,6 +48,7 @@ pub use backtrace::Backtrace;
 pub use compat::Compat;
 pub use context::Context;
 pub use result_ext::ResultExt;
+pub use display::FailDisplay;
 
 #[cfg(feature = "failure_derive")]
 #[allow(unused_imports)]
@@ -228,6 +230,11 @@ impl Fail {
     /// fail use the `skip` method (`fail.causes().skip(1)`).
     pub fn iter_causes(&self) -> Causes {
         Causes { fail: Some(self) }
+    }
+
+    /// Displays the failure.
+    pub fn display(&self) -> FailDisplay {
+        FailDisplay(self, None)
     }
 
     /// Deprecated alias to `find_root_cause`.


### PR DESCRIPTION
When `.display()` is called on an error or fail this renders out the
fail and its causes into a human readable string:

```
error: this is the first error
  caused by: this is the second error
  caused by: this is the third error
```