### PR TITLE
Probe for the dyn syntax instead of version checks.

### DIFF
--- a/failure_derive/Cargo.toml
+++ b/failure_derive/Cargo.toml
@@ -15,6 +15,9 @@ syn = "0.14.4"
 synstructure = "0.9.0"
 proc-macro2 = "0.4.8"
 
+[build-dependencies]
+feature-probe = "0.1.1"
+
 [dev-dependencies.failure]
 version = "0.1.0"
 path = ".."

--- a/failure_derive/build.rs
+++ b/failure_derive/build.rs
@@ -1,39 +1,10 @@
-use std::env;
-use std::process::Command;
-use std::str;
-use std::str::FromStr;
+extern crate feature_probe;
+
+use feature_probe::Probe;
 
 fn main() {
-    if rustc_has_dyn_trait() {
+    let probe = Probe::new();
+    if probe.probe_expression("&() as &dyn Sync") {
         println!("cargo:rustc-cfg=has_dyn_trait");
     }
-}
-
-fn rustc_has_dyn_trait() -> bool {
-    let rustc = match env::var_os("RUSTC") {
-        Some(rustc) => rustc,
-        None => return false,
-    };
-
-    let output = match Command::new(rustc).arg("--version").output() {
-        Ok(output) => output,
-        Err(_) => return false,
-    };
-
-    let version = match str::from_utf8(&output.stdout) {
-        Ok(version) => version,
-        Err(_) => return false,
-    };
-
-    let mut pieces = version.split('.');
-    if pieces.next() != Some("rustc 1") {
-        return true;
-    }
-
-    let next = match pieces.next() {
-        Some(next) => next,
-        None => return false,
-    };
-
-    u32::from_str(next).unwrap_or(0) >= 27
 }


### PR DESCRIPTION
I'm not 100% sure this is the way to go but I think at least conceptionally
it's the better solution.

Fixes #235