### PR TITLE
chain_display with alternate format for linebreaks and backtraces

### DIFF
--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -1,0 +1,48 @@
+extern crate failure;
+
+use std::fmt;
+use failure::{Fail, chain_display};
+
+#[derive(Debug)]
+struct InsideError;
+
+impl fmt::Display for InsideError {
+    fn fmt(&self, fmr: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmr, "Inside Error")
+    }
+}
+
+impl Fail for InsideError {}
+
+#[derive(Debug)]
+struct OutsideError(InsideError);
+
+impl fmt::Display for OutsideError {
+    fn fmt(&self, fmr: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmr, "Outside Error: {}", self.0)
+    }
+}
+
+impl Fail for OutsideError {
+    fn cause(&self) -> Option<&Fail> {
+        Some(&self.0)
+    }
+}
+
+fn bad_function() -> Result<(), OutsideError> {
+    Err(OutsideError(InsideError))
+}
+
+fn main() {
+    println!("### line ({{}}) chain_display ###");
+    if let Err(ref e) = bad_function() {
+        println!("{}", chain_display(e));
+    }
+    println!();
+
+    println!("### block ({{:#}}) chain_display ###");
+    if let Err(ref e) = bad_function() {
+        println!("{:#}", chain_display(e));
+    }
+    println!();
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate failure;
 
-use failure::Fail;
+use failure::chain_display;
 
 #[derive(Debug, Fail)]
 #[fail(display = "my error")]
@@ -16,5 +16,22 @@ fn bad_function() -> Result<(), WrappingError> {
 }
 
 fn main() {
-    println!("{}", Fail::display(&bad_function().unwrap_err()));
+    println!("### default fail(display = \"...\") ###");
+    if let Err(ref e) = bad_function() {
+        println!("{}", e);
+        println!("{:#} (with {{:#}})", e);
+    }
+    println!();
+
+    println!("### line ({{}}) chain_display ###");
+    if let Err(ref e) = bad_function() {
+        println!("{}", chain_display(e));
+    }
+    println!();
+
+    println!("### block ({{:#}}) chain_display ###");
+    if let Err(ref e) = bad_function() {
+        println!("{:#}", chain_display(e));
+    }
+    println!();
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,7 +16,5 @@ fn bad_function() -> Result<(), WrappingError> {
 }
 
 fn main() {
-    for cause in Fail::iter_causes(&bad_function().unwrap_err()) {
-        println!("{}", cause);
-    }
+    println!("{}", Fail::display(&bad_function().unwrap_err()));
 }

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -111,6 +111,11 @@ with_backtrace! {
             Backtrace { internal: InternalBacktrace::new() }
         }
 
+        /// Checks if the backtrace is empty.
+        pub fn is_empty(&self) -> bool {
+            self.internal.is_none()
+        }
+
         pub(crate) fn none() -> Backtrace {
             Backtrace { internal: InternalBacktrace::none() }
         }

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,41 +3,48 @@ use _core::fmt;
 use Fail;
 use backtrace::Backtrace;
 
+/// A custom `Display` adapter for a `Fail` and an optional top-level
+/// Backtrace.  Displays the entire chain from the `Fail` through all causes.
+/// Uses single line formatting with `{}` or multiple-lines incl. backtrace
+/// via the (alternate) `{:#}`
+pub struct ChainDisplay<'a>(pub(crate) &'a Fail, pub(crate) Option<&'a Backtrace>);
 
-/// Renders a fail with all causes.
-pub struct FailDisplay<'a>(pub(crate) &'a Fail, pub(crate) Option<&'a Backtrace>);
-
-impl<'a> fmt::Display for FailDisplay<'a> {
+impl<'a> fmt::Display for ChainDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut ptr = Some(self.0);
+        let mut next = Some(self.0);
         let mut idx = 0;
         let mut was_backtrace = false;
 
-        while let Some(fail) = ptr {
+        while let Some(fail) = next {
             if was_backtrace {
-                write!(f, "\n")?;
+                writeln!(f)?;
             }
             was_backtrace = false;
             if idx == 0 {
-                write!(f, "error: {}", fail)?;
+                if f.alternate() {
+                    write!(f, "error: {:#}", fail)?;
+                } else {
+                    write!(f, "error: {}", fail)?;
+                }
+            } else if f.alternate() {
+                write!(f, "\n  caused by: {:#}", fail)?;
             } else {
-                write!(f, "\n  caused by: {}", fail)?;
+                write!(f, "; caused by: {}", fail)?;
             }
             if f.alternate() {
-                let backtrace = if idx == 0 && self.1.is_some() {
-                    Some(self.1.unwrap())
+                let backtrace = if idx == 0 {
+                    self.1.or_else(|| fail.backtrace())
                 } else {
                     fail.backtrace()
                 };
                 if let Some(backtrace) = backtrace {
-                    write!(f, "\nbacktrace:\n{}", backtrace)?;
+                    write!(f, ", backtrace:\n{:#}", backtrace)?;
                     was_backtrace = true;
                 }
             }
-            ptr = fail.cause();
+            next = fail.cause();
             idx += 1;
         }
-
         Ok(())
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,0 +1,43 @@
+use _core::fmt;
+
+use Fail;
+use backtrace::Backtrace;
+
+
+/// Renders a fail with all causes.
+pub struct FailDisplay<'a>(pub(crate) &'a Fail, pub(crate) Option<&'a Backtrace>);
+
+impl<'a> fmt::Display for FailDisplay<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut ptr = Some(self.0);
+        let mut idx = 0;
+        let mut was_backtrace = false;
+
+        while let Some(fail) = ptr {
+            if was_backtrace {
+                write!(f, "\n")?;
+            }
+            was_backtrace = false;
+            if idx == 0 {
+                write!(f, "error: {}", fail)?;
+            } else {
+                write!(f, "\n  caused by: {}", fail)?;
+            }
+            if f.alternate() {
+                let backtrace = if idx == 0 && self.1.is_some() {
+                    Some(self.1.unwrap())
+                } else {
+                    fail.backtrace()
+                };
+                if let Some(backtrace) = backtrace {
+                    write!(f, "\nbacktrace:\n{}", backtrace)?;
+                    was_backtrace = true;
+                }
+            }
+            ptr = fail.cause();
+            idx += 1;
+        }
+
+        Ok(())
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -15,6 +15,8 @@ use self::error_impl::ErrorImpl;
 #[cfg(feature = "std")]
 use std::error::Error as StdError;
 
+use display::FailDisplay;
+
 
 /// The `Error` type, which can contain any failure.
 ///
@@ -164,6 +166,11 @@ impl Error {
     /// If the underlying error is not of type `T`, this will return `None`.
     pub fn downcast_mut<T: Fail>(&mut self) -> Option<&mut T> {
         self.imp.failure_mut().downcast_mut()
+    }
+
+    /// Displays the error.
+    pub fn display(&self) -> FailDisplay {
+        FailDisplay(self.as_fail(), Some(self.backtrace()))
     }
 
     /// Deprecated alias to `find_root_cause`.

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -15,8 +15,7 @@ use self::error_impl::ErrorImpl;
 #[cfg(feature = "std")]
 use std::error::Error as StdError;
 
-use display::FailDisplay;
-
+use display::ChainDisplay;
 
 /// The `Error` type, which can contain any failure.
 ///
@@ -168,9 +167,9 @@ impl Error {
         self.imp.failure_mut().downcast_mut()
     }
 
-    /// Displays the error.
-    pub fn display(&self) -> FailDisplay {
-        FailDisplay(self.as_fail(), Some(self.backtrace()))
+    /// Return a custom `Display` adapter which show the entire chain of causes.
+    pub fn chain_display(&self) -> ChainDisplay {
+        ChainDisplay(self.as_fail(), Some(self.backtrace()))
     }
 
     /// Deprecated alias to `find_root_cause`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod box_std;
 mod compat;
 mod context;
 mod result_ext;
+mod display;
 
 use core::any::TypeId;
 use core::fmt::{Debug, Display};
@@ -47,6 +48,7 @@ pub use backtrace::Backtrace;
 pub use compat::Compat;
 pub use context::Context;
 pub use result_ext::ResultExt;
+pub use display::FailDisplay;
 
 #[cfg(feature = "failure_derive")]
 #[allow(unused_imports)]
@@ -236,6 +238,11 @@ impl Fail {
     /// fail use `iter_causes` instead.
     pub fn iter_chain(&self) -> Causes {
         Causes { fail: Some(self) }
+    }
+
+    /// Displays the failure.
+    pub fn display(&self) -> FailDisplay {
+        FailDisplay(self, None)
     }
 
     /// Deprecated alias to `find_root_cause`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use backtrace::Backtrace;
 pub use compat::Compat;
 pub use context::Context;
 pub use result_ext::ResultExt;
-pub use display::FailDisplay;
+pub use display::ChainDisplay;
 
 #[cfg(feature = "failure_derive")]
 #[allow(unused_imports)]
@@ -240,9 +240,9 @@ impl Fail {
         Causes { fail: Some(self) }
     }
 
-    /// Displays the failure.
-    pub fn display(&self) -> FailDisplay {
-        FailDisplay(self, None)
+    /// Return a custom `Display` adapter which show the entire chain of causes.
+    pub fn chain_display(&self) -> ChainDisplay {
+        ChainDisplay(self, None)
     }
 
     /// Deprecated alias to `find_root_cause`.
@@ -256,6 +256,14 @@ impl Fail {
     pub fn causes(&self) -> Causes {
         Causes { fail: Some(self) }
     }
+}
+
+/// Return a custom `Display` adapter which shows the entire chain from the
+/// provided `Fail` and all causes. The adapter will use single line
+/// formatting with `{}` or multiple-lines incl. backtrace via the (alternate)
+/// `{:#}`
+pub fn chain_display(fail: &Fail) -> ChainDisplay {
+    ChainDisplay(fail, None)
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This is a riff on #233, prototype based on discussion, of that PR.

* Uses `chain_display() -> ChainDisplay` as rename of `display() -> FailDisplay` 

* Adds a convenient top level `failure::chain_display` function, which simplifies usage (see examples/simple changes).

* Uses single line format for "{}" and multiple lines with backtraces for (`alternate` == true) "{:#}". 

* Propagates alternate format selection to Fail types `Display::fmt`.

* Extends examples/simple.rs with all output variants. (There is not unit or doctests yet to riff on.)

* Adds a example/custom.rs which might demonstrate a typical double (but not particularly harmful) output of an inner error, based on current usage.