### PR TITLE
Allow variant with no #fail attribute

### DIFF
--- a/failure_derive/src/lib.rs
+++ b/failure_derive/src/lib.rs
@@ -69,14 +69,14 @@ fn fail_derive(s: synstructure::Structure) -> TokenStream {
 }
 
 fn display_body(s: &synstructure::Structure) -> Option<quote::__rt::TokenStream> {
-    let mut msgs = s.variants().iter().map(|v| find_error_msg(&v.ast().attrs));
-    if msgs.all(|msg| msg.is_none()) {
-        return None;
-    }
-
     Some(s.each_variant(|v| {
-        let msg =
-            find_error_msg(&v.ast().attrs).expect("All variants must have display attribute.");
+        let msg = match find_error_msg(&v.ast().attrs) {
+            Some(msg) => msg,
+            None => {
+                let variant_name = v.ast().ident.to_string();
+                return quote!( return write!(f, "{}", #variant_name));
+            }
+        };
         if msg.nested.is_empty() {
             panic!("Expected at least one argument to fail attribute");
         }

--- a/failure_derive/tests/tests.rs
+++ b/failure_derive/tests/tests.rs
@@ -53,3 +53,27 @@ fn enum_error() {
     let s = format!("{}", EnumError::UnitVariant);
     assert_eq!(&s[..], "An error has occurred.");
 }
+
+#[derive(Debug, Fail)]
+enum EnumWithNoAttr {
+    #[fail(display = "Error: {}", _0)]
+    TupleVariant(usize),
+    UnitVariant,
+}
+
+#[test]
+fn enum_with_no_attr() {
+    let s = format!("{}", EnumWithNoAttr::TupleVariant(4));
+    assert_eq!(&s[..], "Error: 4");
+    let s = format!("{}", EnumWithNoAttr::UnitVariant);
+    assert_eq!(&s[..], "UnitVariant");
+}
+
+#[derive(Debug, Fail)]
+struct StructWithNoAttr;
+
+#[test]
+fn struct_with_no_attr() {
+    let s = format!("{}", StructWithNoAttr {});
+    assert_eq!(&s[..], "StructWithNoAttr");
+}


### PR DESCRIPTION
If a variant doesn't have fail attribute, use its' name to display.
E.g.
```rust
#[derive(Debug, Fail)]
struct StructWithNoAttr;

#[test]
fn struct_with_no_attr() {
    let s = format!("{}", StructWithNoAttr {});
    assert_eq!(&s[..], "StructWithNoAttr");
}
```

I don't think `All variants must have display attribute` is user friendly, but feel free to close this PR if you don't like it.