### PR TITLE
Fix deprecation notice of `Fail::causes`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub trait Fail: Display + Debug + Send + Sync + 'static {
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "0.1.2", note = "please use the 'iter_causes()' method instead")]
+    #[deprecated(since = "0.1.2", note = "please use the 'iter_chain()' method instead")]
     fn causes(&self) -> Causes
     where
         Self: Sized,
@@ -244,7 +244,7 @@ impl Fail {
         find_root_cause(self)
     }
 
-    /// Deprecated alias to `iter_causes`.
+    /// Deprecated alias to `iter_chain`.
     #[deprecated(since = "0.1.2", note = "please use the 'iter_chain()' method instead")]
     pub fn causes(&self) -> Causes {
         Causes { fail: Some(self) }


### PR DESCRIPTION
`Fail::causes` incorrectly mentions `Fail::iter_causes` where it actually is an alias to `Fail::iter_chain`. I've run into this multiple times now 😓