### PR TITLE
Allow including ensure without explicitly including bail in 2018

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,12 +25,12 @@ macro_rules! bail {
 macro_rules! ensure {
     ($cond:expr, $e:expr) => {
         if !($cond) {
-            bail!($e);
+            $crate::bail!($e);
         }
     };
     ($cond:expr, $fmt:expr, $($arg:tt)+) => {
         if !($cond) {
-            bail!($fmt, $($arg)+);
+            $crate::bail!($fmt, $($arg)+);
         }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -21,16 +21,16 @@ macro_rules! bail {
 /// Similar to `assert!`, `ensure!` takes a condition and exits the function
 /// if the condition fails. Unlike `assert!`, `ensure!` returns an `Error`,
 /// it does not panic.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ensure {
     ($cond:expr, $e:expr) => {
         if !($cond) {
-            $crate::bail!($e);
+            bail!($e);
         }
     };
     ($cond:expr, $fmt:expr, $($arg:tt)+) => {
         if !($cond) {
-            $crate::bail!($fmt, $($arg)+);
+            bail!($fmt, $($arg)+);
         }
     };
 }


### PR DESCRIPTION
This allows 2018 rust users to avoid having to include both the bail and ensure macros if they only want to use ensure.