### PR TITLE
Fix a memory leak in downcast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "failure"
 repository = "https://github.com/rust-lang-nursery/failure"
 version = "0.1.2"
+build = "build.rs"
 
 [dependencies.failure_derive]
 optional = true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,39 @@
+use std::env;
+use std::process::Command;
+use std::str;
+use std::str::FromStr;
+
+fn main() {
+    if rustc_has_global_alloc() {
+        println!("cargo:rustc-cfg=has_global_alloc");
+    }
+}
+
+fn rustc_has_global_alloc() -> bool {
+    let rustc = match env::var_os("RUSTC") {
+        Some(rustc) => rustc,
+        None => return false,
+    };
+
+    let output = match Command::new(rustc).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => return false,
+    };
+
+    let version = match str::from_utf8(&output.stdout) {
+        Ok(version) => version,
+        Err(_) => return false,
+    };
+
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return true;
+    }
+
+    let next = match pieces.next() {
+        Some(next) => next,
+        None => return false,
+    };
+
+    u32::from_str(next).unwrap_or(0) >= 28
+}


### PR DESCRIPTION
This fixes #261 on newer Rust versions. I don't know of a way to fix it for olders.

The deprecation note for older Rusts is also the only way I know in which a user could be informed about this issue.