### PR TITLE
Add a direct link to the intro book from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/rust-lang-nursery/failure.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/failure)
 [![Latest Version](https://img.shields.io/crates/v/failure.svg)](https://crates.io/crates/failure)
 [![docs](https://docs.rs/failure/badge.svg)](https://docs.rs/failure)
+[![book](https://img.shields.io/badge/intro-book-blue.svg)](https://boats.gitlab.io/failure/)
 
 `failure` is designed to make it easier to manage errors in Rust. It is
 intended to replace error management based on `std::error::Error` with a new


### PR DESCRIPTION
# What's this PR do?

It adds a badge to the README that points to the book: [![book](https://img.shields.io/badge/intro-book-blue.svg)](https://boats.gitlab.io/failure/)

I hope the badge text/color is appropriate/readable, let me know if it should say something else. 

Mostly, I'm interested in getting it in there because the repo is the page I always land on (google finds it), but can not easily get anywhere that has a link to the book, so this should help with navigation a bit.