### PR TITLE
Use associated function syntax for `Debug` and `Display` backtrace impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - 1.18.0
+    - 1.25.0
     - stable
     - beta
     - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "./failure_derive"
 
 [dependencies.backtrace]
 optional = true
-version = "=0.3.9"
+version = "0.3.13"
 
 [workspace]
 members = [".", "failure_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "./failure_derive"
 
 [dependencies.backtrace]
 optional = true
-version = "0.3.3"
+version = "=0.3.9"
 
 [workspace]
 members = [".", "failure_derive"]

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ pub fn read_toolchains(path: PathBuf) -> Result<Toolchains, Error>
 ## Requirements
 
 Both failure and failure_derive are intended to compile on all stable versions
-of Rust newer than 1.18.0, as well as the latest beta and the latest nightly.
-If either crate fails to compile on any version newer than 1.18.0, please open
+of Rust newer than 1.25.0, as well as the latest beta and the latest nightly.
+If either crate fails to compile on any version newer than 1.25.0, please open
 an issue.
 
 failure is **no_std** compatible, though some aspects of it (primarily the

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -137,7 +137,7 @@ with_backtrace! {
     impl Display for Backtrace {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(bt) = self.internal.as_backtrace() {
-                Display::fmt(bt, f)
+                Debug::fmt(bt, f)
             } else { Ok(()) }
         }
     }

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -129,7 +129,7 @@ with_backtrace! {
     impl Debug for Backtrace {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(bt) = self.internal.as_backtrace() {
-                bt.fmt(f)
+                Debug::fmt(bt, f)
             } else { Ok(()) }
         }
     }
@@ -137,7 +137,7 @@ with_backtrace! {
     impl Display for Backtrace {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(bt) = self.internal.as_backtrace() {
-                bt.fmt(f)
+                Display::fmt(bt, f)
             } else { Ok(()) }
         }
     }


### PR DESCRIPTION
Rust 1.31 reports a compilation error saying it is ambiguous which
`fmt` method to call.

---

Not sure if this happened prior to Rust 1.31, but when compiling `failure` using Rust 1.31.0 (stable) this error shows up:

```rust
[07:33:30] failure master
$ cargo +stable test --all
...
error[E0034]: multiple applicable items in scope
   --> src\backtrace\mod.rs:132:20
    |
132 |                 bt.fmt(f)
    |                    ^^^ multiple `fmt` found
    |
    = note: candidate #1 is defined in an impl of the trait `std::fmt::Debug` for the type `backtrace::backtrace::Backtrace`
    = note: candidate #2 is defined in an impl of the trait `std::fmt::Display` for the type `backtrace::backtrace::Backtrace`

error[E0034]: multiple applicable items in scope
   --> src\backtrace\mod.rs:140:20
    |
140 |                 bt.fmt(f)
    |                    ^^^ multiple `fmt` found
    |
    = note: candidate #1 is defined in an impl of the trait `std::fmt::Debug` for the type `backtrace::backtrace::Backtrace`
    = note: candidate #2 is defined in an impl of the trait `std::fmt::Display` for the type `backtrace::backtrace::Backtrace`

error: aborting due to 2 previous errors
```
