### PR TITLE
fix for backtrace 0.3.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "./failure_derive"
 
 [dependencies.backtrace]
 optional = true
-version = "0.3.10"
+version = "0.3.3"
 
 [workspace]
 members = [".", "failure_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "./failure_derive"
 
 [dependencies.backtrace]
 optional = true
-version = "0.3.3"
+version = "0.3.10"
 
 [workspace]
 members = [".", "failure_derive"]

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -137,7 +137,7 @@ with_backtrace! {
     impl Display for Backtrace {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(bt) = self.internal.as_backtrace() {
-                Display::fmt(bt, f)
+                Debug::fmt(bt, f)
             } else { Ok(()) }
         }
     }

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -129,7 +129,7 @@ with_backtrace! {
     impl Debug for Backtrace {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(bt) = self.internal.as_backtrace() {
-                bt.fmt(f)
+                Debug::fmt(bt, f)
             } else { Ok(()) }
         }
     }
@@ -137,7 +137,7 @@ with_backtrace! {
     impl Display for Backtrace {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(bt) = self.internal.as_backtrace() {
-                bt.fmt(f)
+                Display::fmt(bt, f)
             } else { Ok(()) }
         }
     }


### PR DESCRIPTION
There's a `Display` instance now, so `bt.fmt` is ambiguous.

Cc https://github.com/rust-lang/rust/pull/56718