### PR TITLE
Add Sync and Send as failure::Error supports them.

### DIFF
--- a/src/compat.rs
+++ b/src/compat.rs
@@ -39,8 +39,8 @@ with_std! {
         }
     }
 
-    impl From<Error> for Box<StdError> {
-        fn from(error: Error) -> Box<StdError> {
+    impl From<Error> for Box<StdError + Send + Sync> {
+        fn from(error: Error) -> Box<StdError + Send + Sync> {
             Box::new(Compat { error })
         }
     }


### PR DESCRIPTION
I trying to use this library with hyper but cann't use `failure::Error` for hyper service as service requires https://docs.rs/hyper/0.12.18/hyper/server/struct.Server.html `Into<Box<dyn std::error::Error + Send + Sync>>` but `failure::Error` could be converted only to `Box<dyn std::error::Error>`

This PR adds Sync and Send markers to because Sync and Send already implemented for `failure::Error`.