### PR TITLE
Fix compat Error conversion 

### DIFF
--- a/src/compat.rs
+++ b/src/compat.rs
@@ -39,6 +39,12 @@ with_std! {
         }
     }
 
+    impl From<Error> for Box<StdError> {
+        fn from(error: Error) -> Box<StdError> {
+            Box::new(Compat { error })
+        }
+    }
+
     impl From<Error> for Box<StdError + Send + Sync> {
         fn from(error: Error) -> Box<StdError + Send + Sync> {
             Box::new(Compat { error })

--- a/tests/fail_compat.rs
+++ b/tests/fail_compat.rs
@@ -1,0 +1,35 @@
+#[macro_use]
+extern crate failure;
+
+use failure::Fail;
+
+fn return_failure() -> Result<(), failure::Error> {
+    #[derive(Fail, Debug)]
+    #[fail(display = "my error")]
+    struct MyError;
+
+    let err = MyError;
+    Err(err.into())
+}
+
+fn return_error() -> Result<(), Box<std::error::Error>> {
+    return_failure()?;
+    Ok(())
+}
+
+fn return_error_send_sync() -> Result<(), Box<std::error::Error + Send + Sync>> {
+    return_failure()?;
+    Ok(())
+}
+
+#[test]
+fn smoke_default_compat() {
+    let err = return_error();
+    assert!(err.is_err());
+}
+
+#[test]
+fn smoke_compat_send_sync() {
+    let err = return_error_send_sync();
+    assert!(err.is_err());
+}


### PR DESCRIPTION
Latest failure(0.1.4) breaks failure Error to std Error (without send and sync) conversion. The changes are related to https://github.com/rust-lang-nursery/failure/pull/283

This PR adds: 
* 2 smoke test cases for error conversion: Error to Box<StdError + Send + Sync> and Error to Box<StdError>
* add conversion from Error to Box<StdError> back