### PR TITLE
[WIP] Failure 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,12 @@ homepage = "https://rust-lang-nursery.github.io/failure/"
 license = "MIT OR Apache-2.0"
 name = "failure"
 repository = "https://github.com/rust-lang-nursery/failure"
-version = "0.1.5"
+version = "0.2.0"
+edition = "2018"
 
 [dependencies.failure_derive]
 optional = true
-version = "0.1.5"
+version = "0.2.0"
 path = "./failure_derive"
 
 [dependencies.backtrace]

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ use failure::Error;
 // We don't do any other magic like creating new types.
 #[derive(Debug, Fail)]
 enum ToolchainError {
-    #[fail(display = "invalid toolchain name: {}", name)]
+    #[error(display = "invalid toolchain name: {}", name)]
     InvalidToolchainName {
         name: String,
     },
-    #[fail(display = "unknown toolchain version: {}", version)]
+    #[error(display = "unknown toolchain version: {}", version)]
     UnknownToolchainVersion {
         version: String,
     }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use failure::Error;
+use failure::DefaultError;
 
 // This is a new error type that you've created. It represents the ways a
 // toolchain could be invalid.

--- a/book/src/custom-fail.md
+++ b/book/src/custom-fail.md
@@ -14,8 +14,8 @@ To implement this pattern, you should define your own type that implements
 example:
 
 ```rust
-#[derive(Fail, Debug)]
-#[fail(display = "Input was invalid UTF-8")]
+#[derive(Error, Debug)]
+#[error(display = "Input was invalid UTF-8")]
 pub struct Utf8Error;
 ```
 
@@ -24,8 +24,8 @@ case. It can be an enum with a different variant for each possible error, and
 it can carry data with more precise information about the error. For example:
 
 ```rust
-#[derive(Fail, Debug)]
-#[fail(display = "Input was invalid UTF-8 at index {}", index)]
+#[derive(Error, Debug)]
+#[error(display = "Input was invalid UTF-8 at index {}", index)]
 pub struct Utf8Error {
     index: usize,
 }
@@ -50,11 +50,11 @@ be inclined to add it as a variant on your own error type. When you do that,
 you should tag the underlying error as the `#[fail(cause)]` of your error:
 
 ```rust
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum MyError {
-    #[fail(display = "Input was invalid UTF-8 at index {}", _0)]
+    #[error(display = "Input was invalid UTF-8 at index {}", _0)]
     Utf8Error(usize),
-    #[fail(display = "{}", _0)]
+    #[error(display = "{}", _0)]
     Io(#[fail(cause)] io::Error),
 }
 ```

--- a/book/src/derive-fail.md
+++ b/book/src/derive-fail.md
@@ -15,7 +15,7 @@ In its smallest form, deriving Fail looks like this:
 
 use std::fmt;
 
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 struct MyError;
 
 impl fmt::Display for MyError {
@@ -36,8 +36,8 @@ You can derive an implementation of `Display` with a special attribute:
 ```rust
 #[macro_use] extern crate failure;
 
-#[derive(Fail, Debug)]
-#[fail(display = "An error occurred.")]
+#[derive(Error, Debug)]
+#[error(display = "An error occurred.")]
 struct MyError;
 ```
 
@@ -54,8 +54,8 @@ formatting and printing macros:
 ```rust
 #[macro_use] extern crate failure;
 
-#[derive(Fail, Debug)]
-#[fail(display = "An error occurred with error code {}. ({})", code, message)]
+#[derive(Error, Debug)]
+#[error(display = "An error occurred with error code {}. ({})", code, message)]
 struct MyError {
     code: i32,
     message: String,
@@ -81,13 +81,13 @@ prefixed with an underscore:
 ```rust
 #[macro_use] extern crate failure;
 
-#[derive(Fail, Debug)]
-#[fail(display = "An error occurred with error code {}.", _0)]
+#[derive(Error, Debug)]
+#[error(display = "An error occurred with error code {}.", _0)]
 struct MyError(i32);
 
 
-#[derive(Fail, Debug)]
-#[fail(display = "An error occurred with error code {} ({}).", _0, _1)]
+#[derive(Error, Debug)]
+#[error(display = "An error occurred with error code {} ({}).", _0, _1)]
 struct MyOtherError(i32, String);
 ```
 
@@ -100,13 +100,13 @@ will match over the enum to generate the correct error message. For example:
 ```rust
 #[macro_use] extern crate failure;
 
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 enum MyError {
-    #[fail(display = "{} is not a valid version.", _0)]
+    #[error(display = "{} is not a valid version.", _0)]
     InvalidVersion(u32),
-    #[fail(display = "IO error: {}", error)]
+    #[error(display = "IO error: {}", error)]
     IoError { error: io::Error },
-    #[fail(display = "An unknown error has occurred.")]
+    #[error(display = "An unknown error has occurred.")]
     UnknownError,
 }
 ```
@@ -122,19 +122,19 @@ field with the type `Backtrace`. This works for both structs and enums.
 use failure::Backtrace;
 
 /// MyError::backtrace will return a reference to the backtrace field
-#[derive(Fail, Debug)]
-#[fail(display = "An error occurred.")]
+#[derive(Error, Debug)]
+#[error(display = "An error occurred.")]
 struct MyError {
     backtrace: Backtrace,
 }
 
 /// MyEnumError::backtrace will return a reference to the backtrace only if it
 /// is Variant2, otherwise it will return None.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 enum MyEnumError {
-    #[fail(display = "An error occurred.")]
+    #[error(display = "An error occurred.")]
     Variant1,
-    #[fail(display = "A different error occurred.")]
+    #[error(display = "A different error occurred.")]
     Variant2(Backtrace),
 }
 ```
@@ -159,19 +159,19 @@ This can be used in fields of enums as well as structs.
 use std::io;
 
 /// MyError::cause will return a reference to the io_error field
-#[derive(Fail, Debug)]
-#[fail(display = "An error occurred.")]
+#[derive(Error, Debug)]
+#[error(display = "An error occurred.")]
 struct MyError {
     #[fail(cause)] io_error: io::Error,
 }
 
 /// MyEnumError::cause will return a reference only if it is Variant2,
 /// otherwise it will return None.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 enum MyEnumError {
-    #[fail(display = "An error occurred.")]
+    #[error(display = "An error occurred.")]
     Variant1,
-    #[fail(display = "A different error occurred.")]
+    #[error(display = "A different error occurred.")]
     Variant2(#[fail(cause)] io::Error),
 }
 ```

--- a/book/src/error-errorkind.md
+++ b/book/src/error-errorkind.md
@@ -27,7 +27,7 @@ enum MyErrorKind {
     // A plain enum with no data in any of its variants
     //
     // For example:
-    #[fail(display = "A contextual error message.")]
+    #[error(display = "A contextual error message.")]
     OneVariant,
     // ...
 }

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use failure::Error;
+use failure::DefaultError;
 
 // This is a new error type that you've created. It represents the ways a
 // toolchain could be invalid.

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -29,11 +29,11 @@ use failure::Error;
 // We don't do any other magic like creating new types.
 #[derive(Debug, Fail)]
 enum ToolchainError {
-    #[fail(display = "invalid toolchain name: {}", name)]
+    #[error(display = "invalid toolchain name: {}", name)]
     InvalidToolchainName {
         name: String,
     },
-    #[fail(display = "unknown toolchain version: {}", version)]
+    #[error(display = "unknown toolchain version: {}", version)]
     UnknownToolchainVersion {
         version: String,
     }

--- a/book/src/use-error.md
+++ b/book/src/use-error.md
@@ -16,7 +16,7 @@ functions:
 use std::io;
 use std::io::BufRead;
 
-use failure::Error;
+use failure::DefaultError;
 use failure::err_msg;
 
 fn my_function() -> Result<(), Error> {

--- a/examples/bail_ensure.rs
+++ b/examples/bail_ensure.rs
@@ -1,14 +1,14 @@
 #[macro_use]
 extern crate failure;
 
-use failure::Error;
+use failure::DefaultError;
 
-fn bailer() -> Result<(), Error> {
+fn bailer() -> Result<(), DefaultError> {
     // bail!("ruh roh");
     bail!("ruh {}", "roh");
 }
 
-fn ensures() -> Result<(), Error> {
+fn ensures() -> Result<(), DefaultError> {
     ensure!(true, "true is false");
     ensure!(false, "false is false");
     Ok(())

--- a/examples/error_as_cause.rs
+++ b/examples/error_as_cause.rs
@@ -4,7 +4,7 @@
 // use failure::{err_msg, Error, Fail};
 
 // #[derive(Debug, Fail)]
-// #[fail(display = "my wrapping error")]
+// #[error(display = "my wrapping error")]
 // struct WrappingError(#[fail(cause)] Error);
 
 // fn bad_function() -> Result<(), WrappingError> {

--- a/examples/error_as_cause.rs
+++ b/examples/error_as_cause.rs
@@ -1,18 +1,19 @@
-#[macro_use]
-extern crate failure;
+// #[macro_use]
+// extern crate failure;
 
-use failure::{err_msg, Error, Fail};
+// use failure::{err_msg, Error, Fail};
 
-#[derive(Debug, Fail)]
-#[fail(display = "my wrapping error")]
-struct WrappingError(#[fail(cause)] Error);
+// #[derive(Debug, Fail)]
+// #[fail(display = "my wrapping error")]
+// struct WrappingError(#[fail(cause)] Error);
 
-fn bad_function() -> Result<(), WrappingError> {
-    Err(WrappingError(err_msg("this went bad")))
-}
+// fn bad_function() -> Result<(), WrappingError> {
+//     Err(WrappingError(err_msg("this went bad")))
+// }
 
 fn main() {
-    for cause in Fail::iter_causes(&bad_function().unwrap_err()) {
-        println!("{}", cause);
-    }
+    // for cause in Fail::iter_causes(&bad_function().unwrap_err()) {
+    //     println!("{}", cause);
+    // }
+    println!("Hello!");
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,13 +3,13 @@ extern crate failure;
 
 use failure::Fail;
 
-#[derive(Debug, Fail)]
-#[fail(display = "my error")]
+#[derive(Error, Debug)]
+#[error(display = "my error")]
 struct MyError;
 
-#[derive(Debug, Fail)]
-#[fail(display = "my wrapping error")]
-struct WrappingError(#[fail(cause)] MyError);
+#[derive(Error, Debug)]
+#[error(display = "my wrapping error")]
+struct WrappingError(#[error(cause)] MyError);
 
 fn bad_function() -> Result<(), WrappingError> {
     Err(WrappingError(MyError))

--- a/failure_derive/Cargo.toml
+++ b/failure_derive/Cargo.toml
@@ -6,8 +6,9 @@ name = "failure_derive"
 repository = "https://github.com/withoutboats/failure_derive"
 homepage = "https://rust-lang-nursery.github.io/failure/"
 documentation = "https://docs.rs/failure"
-version = "0.1.5"
+version = "0.2.0"
 build = "build.rs"
+edition = "2018"
 
 [dependencies]
 quote = "0.6.3"
@@ -16,7 +17,7 @@ synstructure = "0.10.0"
 proc-macro2 = "0.4.8"
 
 [dev-dependencies.failure]
-version = "0.1.0"
+version = "0.2.0"
 path = ".."
 
 [lib]

--- a/failure_derive/src/lib.rs
+++ b/failure_derive/src/lib.rs
@@ -25,7 +25,7 @@ impl DeriveError {
     }
 }
 
-decl_derive!([Fail, attributes(fail, cause)] => fail_derive);
+decl_derive!([Error, attributes(error, cause)] => fail_derive);
 
 fn fail_derive(s: synstructure::Structure) -> TokenStream {
     match fail_derive_impl(s) {
@@ -193,7 +193,7 @@ fn find_error_msg(attrs: &[syn::Attribute]) -> Result<Option<syn::MetaList>, Der
     let mut error_msg = None;
     for attr in attrs {
         if let Some(meta) = attr.interpret_meta() {
-            if meta.name() == "fail" {
+            if meta.name() == "error" {
                 if error_msg.is_some() {
                     return Err(DeriveError::new(
                         meta.span(),
@@ -239,7 +239,7 @@ fn is_cause(bi: &&synstructure::BindingInfo) -> bool {
                 }
                 found_cause = true;
             }
-            if meta.name() == "fail" {
+            if meta.name() == "error" {
                 if let syn::Meta::List(ref list) = meta {
                     if let Some(ref pair) = list.nested.first() {
                         if let &&syn::NestedMeta::Meta(syn::Meta::Word(ref word)) = pair.value() {

--- a/failure_derive/tests/backtrace.rs
+++ b/failure_derive/tests/backtrace.rs
@@ -4,8 +4,8 @@ extern crate failure_derive;
 
 use failure::{Backtrace, Fail};
 
-#[derive(Fail, Debug)]
-#[fail(display = "Error code: {}", code)]
+#[derive(Error, Debug)]
+#[error(display = "Error code: {}", code)]
 struct BacktraceError {
     backtrace: Backtrace,
     code: u32,
@@ -22,8 +22,8 @@ fn backtrace_error() {
     assert!(err.backtrace().is_some());
 }
 
-#[derive(Fail, Debug)]
-#[fail(display = "An error has occurred.")]
+#[derive(Error, Debug)]
+#[error(display = "An error has occurred.")]
 struct BacktraceTupleError(Backtrace);
 
 #[test]
@@ -34,13 +34,13 @@ fn backtrace_tuple_error() {
     assert!(err.backtrace().is_some());
 }
 
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 enum BacktraceEnumError {
-    #[fail(display = "Error code: {}", code)]
+    #[error(display = "Error code: {}", code)]
     StructVariant { code: i32, backtrace: Backtrace },
-    #[fail(display = "Error: {}", _0)]
+    #[error(display = "Error: {}", _0)]
     TupleVariant(&'static str, Backtrace),
-    #[fail(display = "An error has occurred.")]
+    #[error(display = "An error has occurred.")]
     UnitVariant,
 }
 

--- a/failure_derive/tests/custom_type_bounds.rs
+++ b/failure_derive/tests/custom_type_bounds.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use failure::Fail;
 
 #[derive(Debug, Fail)]
-#[fail(display = "An error has occurred.")]
+#[error(display = "An error has occurred.")]
 pub struct UnboundedGenericTupleError<T: 'static + Debug + Send + Sync>(T);
 
 #[test]
@@ -16,7 +16,7 @@ fn unbounded_generic_tuple_error() {
 }
 
 #[derive(Debug, Fail)]
-#[fail(display = "An error has occurred: {}", _0)]
+#[error(display = "An error has occurred: {}", _0)]
 pub struct FailBoundsGenericTupleError<T: Fail>(T);
 
 #[test]
@@ -31,7 +31,7 @@ pub trait NoDisplay: 'static + Debug + Send + Sync {}
 impl NoDisplay for &'static str {}
 
 #[derive(Debug, Fail)]
-#[fail(display = "An error has occurred: {:?}", _0)]
+#[error(display = "An error has occurred: {:?}", _0)]
 pub struct CustomBoundsGenericTupleError<T: NoDisplay>(T);
 
 #[test]

--- a/failure_derive/tests/tests.rs
+++ b/failure_derive/tests/tests.rs
@@ -2,8 +2,8 @@ extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 
-#[derive(Fail, Debug)]
-#[fail(display = "An error has occurred.")]
+#[derive(Error, Debug)]
+#[error(display = "An error has occurred.")]
 struct UnitError;
 
 #[test]
@@ -12,8 +12,8 @@ fn unit_struct() {
     assert_eq!(&s[..], "An error has occurred.");
 }
 
-#[derive(Fail, Debug)]
-#[fail(display = "Error code: {}", code)]
+#[derive(Error, Debug)]
+#[error(display = "Error code: {}", code)]
 struct RecordError {
     code: u32,
 }
@@ -24,8 +24,8 @@ fn record_struct() {
     assert_eq!(&s[..], "Error code: 0");
 }
 
-#[derive(Fail, Debug)]
-#[fail(display = "Error code: {}", _0)]
+#[derive(Error, Debug)]
+#[error(display = "Error code: {}", _0)]
 struct TupleError(i32);
 
 #[test]
@@ -34,13 +34,13 @@ fn tuple_struct() {
     assert_eq!(&s[..], "Error code: 2");
 }
 
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 enum EnumError {
-    #[fail(display = "Error code: {}", code)]
+    #[error(display = "Error code: {}", code)]
     StructVariant { code: i32 },
-    #[fail(display = "Error: {}", _0)]
+    #[error(display = "Error: {}", _0)]
     TupleVariant(&'static str),
-    #[fail(display = "An error has occurred.")]
+    #[error(display = "An error has occurred.")]
     UnitVariant,
 }
 

--- a/failure_derive/tests/wraps.rs
+++ b/failure_derive/tests/wraps.rs
@@ -7,8 +7,8 @@ use std::io;
 
 use failure::{Backtrace, Fail};
 
-#[derive(Fail, Debug)]
-#[fail(display = "An error has occurred: {}", inner)]
+#[derive(Error, Debug)]
+#[error(display = "An error has occurred: {}", inner)]
 struct WrapError {
     #[fail(cause)]
     inner: io::Error,
@@ -24,8 +24,8 @@ fn wrap_error() {
         .is_some());
 }
 
-#[derive(Fail, Debug)]
-#[fail(display = "An error has occurred: {}", _0)]
+#[derive(Error, Debug)]
+#[error(display = "An error has occurred: {}", _0)]
 struct WrapTupleError(#[fail(cause)] io::Error);
 
 #[test]
@@ -38,8 +38,8 @@ fn wrap_tuple_error() {
         .is_some());
 }
 
-#[derive(Fail, Debug)]
-#[fail(display = "An error has occurred: {}", inner)]
+#[derive(Error, Debug)]
+#[error(display = "An error has occurred: {}", inner)]
 struct WrapBacktraceError {
     #[fail(cause)]
     inner: io::Error,
@@ -60,11 +60,11 @@ fn wrap_backtrace_error() {
     assert!(err.backtrace().is_some());
 }
 
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 enum WrapEnumError {
-    #[fail(display = "An error has occurred: {}", _0)]
+    #[error(display = "An error has occurred: {}", _0)]
     Io(#[fail(cause)] io::Error),
-    #[fail(display = "An error has occurred: {}", inner)]
+    #[error(display = "An error has occurred: {}", inner)]
     Fmt {
         #[fail(cause)]
         inner: fmt::Error,

--- a/src/as_fail.rs
+++ b/src/as_fail.rs
@@ -1,4 +1,4 @@
-use Fail;
+use crate::Fail;
 
 /// The `AsFail` trait
 ///
@@ -27,7 +27,7 @@ impl AsFail for Fail {
 }
 
 with_std! {
-    use error::Error;
+    use std::error::Error;
 
     impl AsFail for Error {
         fn as_fail(&self) -> &Fail {

--- a/src/box_std.rs
+++ b/src/box_std.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use std::fmt;
-use Fail;
+use crate::Fail;
 
 pub struct BoxStd(pub Box<Error + Send + Sync + 'static>);
 

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -31,7 +31,7 @@ with_std! {
     use std::fmt::Debug;
     use std::error::Error as StdError;
 
-    use crate::Error;
+    use crate::DefaultError;
 
     impl<E: Display + Debug> StdError for Compat<E> {
         fn description(&self) -> &'static str {
@@ -39,14 +39,14 @@ with_std! {
         }
     }
 
-    impl From<Error> for Box<StdError> {
-        fn from(error: Error) -> Box<StdError> {
+    impl From<DefaultError> for Box<StdError> {
+        fn from(error: DefaultError) -> Box<StdError> {
             Box::new(Compat { error })
         }
     }
 
-    impl From<Error> for Box<StdError + Send + Sync> {
-        fn from(error: Error) -> Box<StdError + Send + Sync> {
+    impl From<DefaultError> for Box<StdError + Send + Sync> {
+        fn from(error: DefaultError) -> Box<StdError + Send + Sync> {
             Box::new(Compat { error })
         }
     }

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -31,7 +31,7 @@ with_std! {
     use std::fmt::Debug;
     use std::error::Error as StdError;
 
-    use Error;
+    use crate::Error;
 
     impl<E: Display + Debug> StdError for Compat<E> {
         fn description(&self) -> &'static str {

--- a/src/context.rs
+++ b/src/context.rs
@@ -63,7 +63,7 @@ without_std! {
 }
 
 with_std! {
-    use crate::{Error, backtrace::Backtrace};
+    use crate::{DefaultError, backtrace::Backtrace};
 
     /// An error with context around it.
     ///
@@ -75,7 +75,7 @@ with_std! {
     /// `Debug` impl also prints the underlying error.
     pub struct Context<D: Display + Send + Sync + 'static> {
         context: D,
-        failure: Either<Backtrace, Error>,
+        failure: Either<Backtrace, DefaultError>,
     }
 
     impl<D: Display + Send + Sync + 'static> Context<D> {
@@ -101,7 +101,7 @@ with_std! {
             }
         }
 
-        pub(crate) fn with_err<E: Into<Error>>(context: D, error: E) -> Context<D> {
+        pub(crate) fn with_err<E: Into<DefaultError>>(context: D, error: E) -> Context<D> {
             let failure = Either::That(error.into());
             Context { context, failure }
         }
@@ -138,7 +138,7 @@ with_std! {
         That(B),
     }
 
-    impl Either<Backtrace, Error> {
+    impl Either<Backtrace, DefaultError> {
         fn backtrace(&self) -> &Backtrace {
             match *self {
                 Either::This(ref backtrace) => backtrace,
@@ -154,7 +154,7 @@ with_std! {
         }
     }
 
-    impl Debug for Either<Backtrace, Error> {
+    impl Debug for Either<Backtrace, DefaultError> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match *self {
                 Either::This(ref backtrace) => write!(f, "{:?}", backtrace),

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,6 @@
 use core::fmt::{self, Debug, Display};
 
-use Fail;
+use crate::Fail;
 
 without_std! {
     /// An error with context around it.
@@ -63,7 +63,7 @@ without_std! {
 }
 
 with_std! {
-    use {Error, Backtrace};
+    use crate::{Error, backtrace::Backtrace};
 
     /// An error with context around it.
     ///

--- a/src/error/error_impl.rs
+++ b/src/error/error_impl.rs
@@ -1,7 +1,7 @@
 use core::any::TypeId;
 
-use Fail;
-use backtrace::Backtrace;
+use crate::Fail;
+use crate::backtrace::Backtrace;
 
 pub(crate) struct ErrorImpl {
     inner: Box<Inner<Fail>>,

--- a/src/error/error_impl_small.rs
+++ b/src/error/error_impl_small.rs
@@ -3,7 +3,7 @@ use std::heap::{Heap, Alloc, Layout};
 use core::mem;
 use core::ptr;
 
-use Fail;
+use crate::Fail;
 use backtrace::Backtrace;
 
 pub(crate) struct ErrorImpl {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,12 +1,12 @@
 use core::fmt::{self, Display, Debug};
 
-use {Causes, Fail};
-use backtrace::Backtrace;
-use context::Context;
-use compat::Compat;
+use crate::{Causes, Fail};
+use crate::Backtrace;
+use crate::context::Context;
+use crate::compat::Compat;
 
 #[cfg(feature = "std")]
-use box_std::BoxStd;
+use crate::box_std::BoxStd;
 
 #[cfg_attr(feature = "small-error", path = "./error_impl_small.rs")]
 mod error_impl;
@@ -174,7 +174,7 @@ impl Error {
     /// Deprecated alias to `find_root_cause`.
     #[deprecated(since = "0.1.2", note = "please use the 'find_root_cause()' method instead")]
     pub fn root_cause(&self) -> &Fail {
-        ::find_root_cause(self.as_fail())
+        crate::find_root_cause(self.as_fail())
     }
 
     /// Deprecated alias to `iter_causes`.
@@ -221,10 +221,12 @@ mod test {
 
     #[test]
     fn methods_seem_to_work() {
+        use crate::backtrace::Backtrace;
+
         let io_error: io::Error = io::Error::new(io::ErrorKind::NotFound, "test");
         let error: Error = io::Error::new(io::ErrorKind::NotFound, "test").into();
         assert!(error.downcast_ref::<io::Error>().is_some());
-        let _: ::Backtrace = *error.backtrace();
+        let _: Backtrace = *error.backtrace();
         assert_eq!(format!("{:?}", io_error), format!("{:?}", error));
         assert_eq!(format!("{}", io_error), format!("{}", error));
         drop(error);

--- a/src/error_message.rs
+++ b/src/error_message.rs
@@ -1,15 +1,15 @@
 use core::fmt::{self, Display, Debug};
 
 use crate::Fail;
-use crate::Error;
+use crate::DefaultError;
 
 /// Constructs a `Fail` type from a string.
 ///
 /// This is a convenient way to turn a string into an error value that
 /// can be passed around, if you do not want to create a new `Fail` type for
 /// this use case.
-pub fn err_msg<D: Display + Debug + Sync + Send + 'static>(msg: D) -> Error {
-    Error::from(ErrorMessage { msg })
+pub fn err_msg<D: Display + Debug + Sync + Send + 'static>(msg: D) -> DefaultError {
+    DefaultError::from(ErrorMessage { msg })
 }
 
 /// A `Fail` type that just contains an error message. You can construct
@@ -21,7 +21,7 @@ struct ErrorMessage<D: Display + Debug + Sync + Send + 'static> {
 
 impl<D: Display + Debug + Sync + Send + 'static> Fail for ErrorMessage<D> {
     fn name(&self) -> Option<&str> {
-        Some("failure::ErrorMessage")
+        Some("failure::DefaultErrorMessage")
     }
 }
 

--- a/src/error_message.rs
+++ b/src/error_message.rs
@@ -1,7 +1,7 @@
 use core::fmt::{self, Display, Debug};
 
-use Fail;
-use Error;
+use crate::Fail;
+use crate::Error;
 
 /// Constructs a `Fail` type from a string.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,10 +69,10 @@ with_std! {
 
     use std::error::Error as StdError;
 
-    pub use crate::error::Error;
+    pub use crate::error::DefaultError;
 
     /// A common result with an `Error`.
-    pub type Fallible<T> = Result<T, Error>;
+    pub type Fallible<T> = Result<T, DefaultError>;
 
     mod macros;
     mod error_message;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,11 @@ mod result_ext;
 use core::any::TypeId;
 use core::fmt::{Debug, Display};
 
-pub use as_fail::AsFail;
-pub use backtrace::Backtrace;
-pub use compat::Compat;
-pub use context::Context;
-pub use result_ext::ResultExt;
+pub use crate::as_fail::AsFail;
+pub use crate::backtrace::Backtrace;
+pub use crate::compat::Compat;
+pub use crate::context::Context;
+pub use crate::result_ext::ResultExt;
 
 #[cfg(feature = "failure_derive")]
 #[allow(unused_imports)]
@@ -63,20 +63,20 @@ with_std! {
     extern crate core;
 
     mod sync_failure;
-    pub use sync_failure::SyncFailure;
+    pub use crate::sync_failure::SyncFailure;
 
     mod error;
 
     use std::error::Error as StdError;
 
-    pub use error::Error;
+    pub use crate::error::Error;
 
     /// A common result with an `Error`.
     pub type Fallible<T> = Result<T, Error>;
 
     mod macros;
     mod error_message;
-    pub use error_message::err_msg;
+    pub use crate::error_message::err_msg;
 }
 
 /// The `Fail` trait.

--- a/src/result_ext.rs
+++ b/src/result_ext.rs
@@ -45,7 +45,7 @@ pub trait ResultExt<T, E> {
     /// #
     /// # pub fn run_test() {
     ///
-    /// let x = (|| -> Result<(), failure::Error> {
+    /// let x = (|| -> Result<(), failure::DefaultError> {
     ///     Err(CustomError).compat()?
     /// })().with_context(|e| {
     ///     format!("An error occured: {}", e)
@@ -87,7 +87,7 @@ pub trait ResultExt<T, E> {
     /// #
     /// # pub fn run_test() {
     ///  
-    /// let x = (|| -> Result<(), failure::Error> {
+    /// let x = (|| -> Result<(), failure::DefaultError> {
     ///     Err(CustomError)?
     /// })().context(format!("An error occured")).unwrap_err();
     ///
@@ -130,7 +130,7 @@ pub trait ResultExt<T, E> {
     /// #
     /// # pub fn run_test() {
     ///
-    /// let x = (|| -> Result<(), failure::Error> {
+    /// let x = (|| -> Result<(), failure::DefaultError> {
     ///     Err(CustomError)?
     /// })().with_context(|e| {
     ///     format!("An error occured: {}", e)
@@ -177,10 +177,10 @@ where
 }
 
 with_std! {
-    use crate::Error;
+    use crate::DefaultError;
 
-    impl<T> ResultExt<T, Error> for Result<T, Error> {
-        fn compat(self) -> Result<T, Compat<Error>> {
+    impl<T> ResultExt<T, DefaultError> for Result<T, DefaultError> {
+        fn compat(self) -> Result<T, Compat<DefaultError>> {
             self.map_err(|err| err.compat())
         }
 
@@ -191,7 +191,7 @@ with_std! {
         }
 
         fn with_context<F, D>(self, f: F) -> Result<T, Context<D>> where
-            F: FnOnce(&Error) -> D,
+            F: FnOnce(&DefaultError) -> D,
             D: Display + Send + Sync + 'static
         {
             self.map_err(|failure| {

--- a/src/result_ext.rs
+++ b/src/result_ext.rs
@@ -81,8 +81,8 @@ pub trait ResultExt<T, E> {
     /// #
     /// # use failure::{self, ResultExt};
     /// #
-    /// #[derive(Fail, Debug)]
-    /// #[fail(display = "")]
+    /// #[derive(Error, Debug)]
+    /// #[error(display = "")]
     /// struct CustomError;
     /// #
     /// # pub fn run_test() {
@@ -124,8 +124,8 @@ pub trait ResultExt<T, E> {
     /// #
     /// # use failure::{self, ResultExt};
     /// #
-    /// #[derive(Fail, Debug)]
-    /// #[fail(display = "My custom error message")]
+    /// #[derive(Error, Debug)]
+    /// #[error(display = "My custom error message")]
     /// struct CustomError;
     /// #
     /// # pub fn run_test() {

--- a/src/result_ext.rs
+++ b/src/result_ext.rs
@@ -1,6 +1,6 @@
 use core::fmt::Display;
 
-use {Compat, Context, Fail};
+use crate::{Compat, Context, Fail};
 
 /// Extension methods for `Result`.
 pub trait ResultExt<T, E> {
@@ -22,7 +22,7 @@ pub trait ResultExt<T, E> {
     /// #
     /// # extern crate failure;
     /// #
-    /// # use tests::failure::ResultExt;
+    /// # use crate::tests::failure::ResultExt;
     /// #
     /// # #[derive(Debug)]
     /// struct CustomError;
@@ -177,7 +177,7 @@ where
 }
 
 with_std! {
-    use Error;
+    use crate::Error;
 
     impl<T> ResultExt<T, Error> for Result<T, Error> {
         fn compat(self) -> Result<T, Compat<Error>> {

--- a/src/sync_failure.rs
+++ b/src/sync_failure.rs
@@ -27,7 +27,7 @@ impl<E: Error + Send + 'static> SyncFailure<E> {
     ///
     /// # use std::error::Error as StdError;
     /// # use std::fmt::{self, Display};
-    /// use failure::{Error, SyncFailure};
+    /// use failure::{DefaultError, SyncFailure};
     /// use std::cell::RefCell;
     ///
     /// #[derive(Debug)]
@@ -56,7 +56,7 @@ impl<E: Error + Send + 'static> SyncFailure<E> {
     ///     # Ok(())
     /// }
     ///
-    /// fn my_function() -> Result<(), Error> {
+    /// fn my_function() -> Result<(), DefaultError> {
     ///     // without the map_err here, we end up with a compile error
     ///     // complaining that NonSyncError doesn't implement Sync.
     ///     returns_error().map_err(SyncFailure::new)?;

--- a/src/sync_failure.rs
+++ b/src/sync_failure.rs
@@ -1,4 +1,4 @@
-use Fail;
+use crate::Fail;
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
 use std::sync::Mutex;

--- a/tests/basic_fail.rs
+++ b/tests/basic_fail.rs
@@ -5,8 +5,8 @@ use failure::Fail;
 
 #[test]
 fn test_name() {
-    #[derive(Fail, Debug)]
-    #[fail(display = "my error")]
+    #[derive(Error, Debug)]
+    #[error(display = "my error")]
     struct MyError;
 
     let err = MyError;

--- a/tests/fail_compat.rs
+++ b/tests/fail_compat.rs
@@ -3,7 +3,7 @@ extern crate failure;
 
 use failure::Fail;
 
-fn return_failure() -> Result<(), failure::Error> {
+fn return_failure() -> Result<(), failure::DefaultError> {
     #[derive(Error, Debug)]
     #[error(display = "my error")]
     struct MyError;

--- a/tests/fail_compat.rs
+++ b/tests/fail_compat.rs
@@ -4,8 +4,8 @@ extern crate failure;
 use failure::Fail;
 
 fn return_failure() -> Result<(), failure::Error> {
-    #[derive(Fail, Debug)]
-    #[fail(display = "my error")]
+    #[derive(Error, Debug)]
+    #[error(display = "my error")]
     struct MyError;
 
     let err = MyError;

--- a/tests/macro_trailing_comma.rs
+++ b/tests/macro_trailing_comma.rs
@@ -13,7 +13,7 @@ extern crate failure;
 // can treat it as a Result-returning function.
 macro_rules! wrap_early_return {
     ($expr:expr) => {{
-        fn func() -> Result<(), failure::Error> {
+        fn func() -> Result<(), failure::DefaultError> {
             let _ = $expr;
 
             #[allow(unreachable_code)]


### PR DESCRIPTION
Hi! This PR introduces a few of the things I've talked about in #287, namely:

- [x] Compile on the 2018 Edition
- [x] Rename `#[derive(Fail)]` to`#[derive(Error)]`
- [x] Rename `failure::Error` to `failure::DefaultError`

Still needed:

- [ ] Review all documentation for accuracy
- [ ] Compile without warnings, especially in the `AsFail for Fail` definition.
- [ ] Rename `Fail` to `ErrorExt`
- [ ] Change the derive to work on `std::error::Error`, pending backtrace support in `std`. This _might_ need to wait until Failure 0.3, however—I haven't thought through the ramifications of that breaking change.

Feedback, help and contributions are welcome!
