### PR TITLE
Add an is_empty method to Backtrace

### DIFF
--- a/failure_derive/tests/wraps.rs
+++ b/failure_derive/tests/wraps.rs
@@ -58,6 +58,8 @@ fn wrap_backtrace_error() {
         .and_then(|err| err.downcast_ref::<io::Error>())
         .is_some());
     assert!(err.backtrace().is_some());
+    assert!(err.backtrace().is_empty());
+    assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
 }
 
 #[derive(Fail, Debug)]
@@ -91,4 +93,6 @@ fn wrap_enum_error() {
         .and_then(|err| err.downcast_ref::<fmt::Error>())
         .is_some());
     assert!(err.backtrace().is_some());
+    assert!(err.backtrace().is_empty());
+    assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
 }

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -52,6 +52,16 @@ without_backtrace! {
         pub(crate) fn is_none(&self) -> bool {
             true
         }
+
+        /// Returns true if displaying this backtrace would be an empty string.
+        ///
+        /// > (We have detected that this crate was documented with no_std
+        /// > compatibility turned on. The version of this crate that has been
+        /// > documented here will never generate a backtrace and this method
+        /// > will always return true.)
+        pub fn is_empty(&self) -> bool {
+            true
+        }
     }
 
     impl Default for Backtrace {
@@ -116,6 +126,11 @@ with_backtrace! {
         }
 
         pub(crate) fn is_none(&self) -> bool {
+            self.internal.is_none()
+        }
+
+        /// Returns true if displaying this backtrace would be an empty string.
+        pub fn is_empty(&self) -> bool {
             self.internal.is_none()
         }
     }


### PR DESCRIPTION
👋 Just a little fix for a little paper cut! 💖 

Fixes #162.

The purpose of this method is to enable testing for when printing a
backtrace will be an empty string because the environment variable
wasn't enabled without needing to Display the backtrace and test for
empty string.

Always returns true in no_std mode because there isn't a backtrace so
the Display will always be empty string.