### PR TITLE
unwrap the Option to access the backtrace

### DIFF
--- a/failure_derive/tests/wraps.rs
+++ b/failure_derive/tests/wraps.rs
@@ -58,8 +58,11 @@ fn wrap_backtrace_error() {
         .and_then(|err| err.downcast_ref::<io::Error>())
         .is_some());
     assert!(err.backtrace().is_some());
-    assert!(err.backtrace().is_empty());
-    assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
+    assert!(err.backtrace().unwrap().is_empty());
+    assert_eq!(
+        err.backtrace().unwrap().is_empty(),
+        err.backtrace().unwrap().to_string().trim().is_empty()
+    );
 }
 
 #[derive(Fail, Debug)]
@@ -93,6 +96,9 @@ fn wrap_enum_error() {
         .and_then(|err| err.downcast_ref::<fmt::Error>())
         .is_some());
     assert!(err.backtrace().is_some());
-    assert!(err.backtrace().is_empty());
-    assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
+    assert!(err.backtrace().unwrap().is_empty());
+    assert_eq!(
+        err.backtrace().unwrap().is_empty(),
+        err.backtrace().unwrap().to_string().trim().is_empty()
+    );
 }


### PR DESCRIPTION
On master running `cargo test --all` fails with:

```
error[E0599]: no method named `is_empty` found for type `std::option::Option<&failure::Backtrace>` in the current scope
  --> failure_derive/tests/wraps.rs:61:29
   |
61 |     assert!(err.backtrace().is_empty());
   |                             ^^^^^^^^

error[E0599]: no method named `is_empty` found for type `std::option::Option<&failure::Backtrace>` in the current scope
  --> failure_derive/tests/wraps.rs:62:32
   |
62 |     assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
   |                                ^^^^^^^^

error[E0599]: no method named `to_string` found for type `std::option::Option<&failure::Backtrace>` in the current scope
  --> failure_derive/tests/wraps.rs:62:60
   |
62 |     assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
   |                                                            ^^^^^^^^^
   |
   = note: the method `to_string` exists but the following trait bounds were not satisfied:
           `std::option::Option<&failure::Backtrace> : std::string::ToString`

error[E0599]: no method named `is_empty` found for type `std::option::Option<&failure::Backtrace>` in the current scope
  --> failure_derive/tests/wraps.rs:96:29
   |
96 |     assert!(err.backtrace().is_empty());
   |                             ^^^^^^^^

error[E0599]: no method named `is_empty` found for type `std::option::Option<&failure::Backtrace>` in the current scope
  --> failure_derive/tests/wraps.rs:97:32
   |
97 |     assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
   |                                ^^^^^^^^

error[E0599]: no method named `to_string` found for type `std::option::Option<&failure::Backtrace>` in the current scope
  --> failure_derive/tests/wraps.rs:97:60
   |
97 |     assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
   |                                                            ^^^^^^^^^
   |
   = note: the method `to_string` exists but the following trait bounds were not satisfied:
           `std::option::Option<&failure::Backtrace> : std::string::ToString`
```