### PR TITLE
Fix URL to documentation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! An experimental new error-handling library. Guide-style introduction
-//! is available [here](https://boats.gitlab.io/failure/).
+//! is available [here](https://rust-lang-nursery.github.io/failure/).
 //!
 //! The primary items exported by this library are:
 //!


### PR DESCRIPTION
The docs at https://docs.rs/failure/0.1.5/failure/ were linking to the pre-nursery versions of the docs from withoutboats; this is harmful as the recommended use has evolved.