### PR TITLE
Mark ATOMIC_USIZE_INIT as deprecated

### DIFF
--- a/src/backtrace/internal.rs
+++ b/src/backtrace/internal.rs
@@ -2,7 +2,7 @@ use std::cell::UnsafeCell;
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 pub use super::backtrace::Backtrace;
@@ -24,7 +24,7 @@ unsafe impl Sync for MaybeResolved {}
 
 impl InternalBacktrace {
     pub(super) fn new() -> InternalBacktrace {
-        static ENABLED: AtomicUsize = ATOMIC_USIZE_INIT;
+        static ENABLED: AtomicUsize = AtomicUsize::new(0);
 
         match ENABLED.load(Ordering::SeqCst) {
             0 => {

--- a/src/backtrace/internal.rs
+++ b/src/backtrace/internal.rs
@@ -2,7 +2,8 @@ use std::cell::UnsafeCell;
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
-use std::sync::atomic::{AtomicUsize, Ordering};
+#[allow(deprecated)] // to allow for older Rust versions (<1.24)
+use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 use std::sync::Mutex;
 
 pub use super::backtrace::Backtrace;
@@ -24,7 +25,8 @@ unsafe impl Sync for MaybeResolved {}
 
 impl InternalBacktrace {
     pub(super) fn new() -> InternalBacktrace {
-        static ENABLED: AtomicUsize = AtomicUsize::new(0);
+        #[allow(deprecated)] // to allow for older Rust versions (<1.24)
+        static ENABLED: AtomicUsize = ATOMIC_USIZE_INIT;
 
         match ENABLED.load(Ordering::SeqCst) {
             0 => {


### PR DESCRIPTION
This fixes the nightly failures