### PR TITLE
Mark struct Context as must_use

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -11,6 +11,7 @@ without_std! {
     ///
     /// The `Display` impl for `Context` only prints the human-readable context, while the
     /// `Debug` impl also prints the underlying error.
+    #[must_use]
     pub struct Context<D: Display + Send + Sync + 'static> {
         context: D,
     }
@@ -73,6 +74,7 @@ with_std! {
     ///
     /// The `Display` impl for `Context` only prints the human-readable context, while the
     /// `Debug` impl also prints the underlying error.
+    #[must_use]
     pub struct Context<D: Display + Send + Sync + 'static> {
         context: D,
         failure: Either<Backtrace, Error>,


### PR DESCRIPTION
Otherwise calling .context() on a result using ResultExt will
not trigger a warning if the result remains unused, e.g.

```
fallible_function().context("bar");
```