### PR TITLE
Require newer `backtrace` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "./failure_derive"
 
 [dependencies.backtrace]
 optional = true
-version = "0.3.3"
+version = "0.3.13"
 
 [workspace]
 members = [".", "failure_derive"]


### PR DESCRIPTION
`failure` does not compile with backtrace-0.3.3 (as specified in Cargo.toml of failure).
It should be updated.

* * *

I tried to check whether my project compiles with minimal dependency versions to check `Cargo.toml`, but failed because one of deps uses `failure` and it accepts too old `backtrace`.

My environment is:
* Gentoo Linux x86\_64
* rustc-1.34.1 stable
    + I used `1.36.0-nightly (e305df184 2019-04-24)` to generate `Cargo.toml` with minimal deps versions, but I don't use it to compile and test the crate.

I tried 0.3.3 -- 0.3.12, but they all failed to compile.
With backtrace-0.3.13, compiles successfully.

With `version = "0.3.12"` for `backtrace`:

<details>

```
$ cargo +nightly update -Z minimal-versions && cargo test --all-features --verbose
    Updating crates.io index
       Fresh unicode-xid v0.1.0
       Fresh cc v1.0.0
       Fresh rustc-demangle v0.1.4
       Fresh cfg-if v0.1.0
       Fresh proc-macro2 v0.4.8
       Fresh quote v0.6.3
   Compiling syn v0.15.0
   Compiling backtrace-sys v0.1.17
       Fresh libc v0.2.45
     Running `rustc --crate-name syn /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-0.15.0/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -
-cfg 'feature="clone-impls"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="extra-traits"' --cfg 'feature="parsing"' --cfg 'feature="printing"' --cfg 'feature="proc-macro
"' --cfg 'feature="proc-macro2"' --cfg 'feature="quote"' --cfg 'feature="visit"' -C metadata=d11856994fd8305f -C extra-filename=-d11856994fd8305f --out-dir /home/lo48576/works/public/contrib
/failure/target/debug/deps -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps --extern proc_macro2=/home/lo48576/works/public/contrib/failure/target/debug/deps/libpro
c_macro2-9efc4637933a1c09.rlib --extern quote=/home/lo48576/works/public/contrib/failure/target/debug/deps/libquote-af3aaac9b3bdf216.rlib --extern unicode_xid=/home/lo48576/works/public/cont
rib/failure/target/debug/deps/libunicode_xid-3579a4bd1835b24e.rlib --cap-lints allow`
     Running `/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-731d700607af3f82/build-script-build`
   Compiling synstructure v0.10.0
     Running `rustc --crate-name synstructure /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/synstructure-0.10.0/src/lib.rs --color always --crate-type lib --emit=dep-info,lin
k -C debuginfo=2 -C metadata=7bc10f70af82650c -C extra-filename=-7bc10f70af82650c --out-dir /home/lo48576/works/public/contrib/failure/target/debug/deps -L dependency=/home/lo48576/works/pub
lic/contrib/failure/target/debug/deps --extern proc_macro2=/home/lo48576/works/public/contrib/failure/target/debug/deps/libproc_macro2-9efc4637933a1c09.rlib --extern quote=/home/lo48576/work
s/public/contrib/failure/target/debug/deps/libquote-af3aaac9b3bdf216.rlib --extern syn=/home/lo48576/works/public/contrib/failure/target/debug/deps/libsyn-d11856994fd8305f.rlib --extern unic
ode_xid=/home/lo48576/works/public/contrib/failure/target/debug/deps/libunicode_xid-3579a4bd1835b24e.rlib --cap-lints allow`
     Running `rustc --crate-name backtrace_sys /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-sys-0.1.17/src/lib.rs --color always --crate-type lib --emit=dep-info,l
ink -C debuginfo=2 -C metadata=b1cf48c04e38413f -C extra-filename=-b1cf48c04e38413f --out-dir /home/lo48576/works/public/contrib/failure/target/debug/deps -L dependency=/home/lo48576/works/p
ublic/contrib/failure/target/debug/deps --extern libc=/home/lo48576/works/public/contrib/failure/target/debug/deps/liblibc-3b524ef2d6fa4eb7.rlib --cap-lints allow -L native=/home/lo48576/wor
ks/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs -l static=backtrace`
   Compiling backtrace v0.3.12
     Running `rustc --crate-name backtrace /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.12/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C d
ebuginfo=2 --cfg 'feature="backtrace-sys"' --cfg 'feature="coresymbolication"' --cfg 'feature="dbghelp"' --cfg 'feature="default"' --cfg 'feature="dladdr"' --cfg 'feature="libbacktrace"' --c
fg 'feature="libunwind"' --cfg 'feature="std"' -C metadata=8b172223bca3120e -C extra-filename=-8b172223bca3120e --out-dir /home/lo48576/works/public/contrib/failure/target/debug/deps -L depe
ndency=/home/lo48576/works/public/contrib/failure/target/debug/deps --extern backtrace_sys=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace_sys-b1cf48c04e38413f.rlib
 --extern cfg_if=/home/lo48576/works/public/contrib/failure/target/debug/deps/libcfg_if-cf437c8c3a7cfcc3.rlib --extern libc=/home/lo48576/works/public/contrib/failure/target/debug/deps/libli
bc-3b524ef2d6fa4eb7.rlib --extern rustc_demangle=/home/lo48576/works/public/contrib/failure/target/debug/deps/librustc_demangle-52276abf4bd0e9fa.rlib --cap-lints allow -L native=/home/lo4857
6/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
error: unexpected end of macro invocation
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.12/src/lib.rs:105:6
    |
105 |     }
    |      ^ missing tokens in macro arguments

error: unexpected end of macro invocation
 --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.12/src/symbolize/mod.rs:7:6
  |
7 |     }
  |      ^ missing tokens in macro arguments

error: unexpected end of macro invocation
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.12/src/lib.rs:128:6
    |
128 |     }
    |      ^ missing tokens in macro arguments

error[E0433]: failed to resolve: use of undeclared type or module `Path`
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.12/src/symbolize/mod.rs:130:26
    |
130 |                     Some(Path::new(OsStr::from_bytes(slice)))
    |                          ^^^^ use of undeclared type or module `Path`

error[E0412]: cannot find type `Path` in this scope
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.12/src/symbolize/mod.rs:122:39
    |
122 |     pub fn filename(&self) -> Option<&Path> {
    |                                       ^^^^ not found in this scope
help: possible candidate is found in another module, you can import it into scope
    |
1   | use std::path::Path;
    |

error: aborting due to 5 previous errors

Some errors occurred: E0412, E0433.
For more information about an error, try `rustc --explain E0412`.
error: Could not compile `backtrace`.

Caused by:
  process didn't exit successfully: `rustc --crate-name backtrace /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.12/src/lib.rs --color always --crate-type lib --
emit=dep-info,link -C debuginfo=2 --cfg 'feature="backtrace-sys"' --cfg 'feature="coresymbolication"' --cfg 'feature="dbghelp"' --cfg 'feature="default"' --cfg 'feature="dladdr"' --cfg 'feat
ure="libbacktrace"' --cfg 'feature="libunwind"' --cfg 'feature="std"' -C metadata=8b172223bca3120e -C extra-filename=-8b172223bca3120e --out-dir /home/lo48576/works/public/contrib/failure/ta
rget/debug/deps -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps --extern backtrace_sys=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace_sy
s-b1cf48c04e38413f.rlib --extern cfg_if=/home/lo48576/works/public/contrib/failure/target/debug/deps/libcfg_if-cf437c8c3a7cfcc3.rlib --extern libc=/home/lo48576/works/public/contrib/failure/
target/debug/deps/liblibc-3b524ef2d6fa4eb7.rlib --extern rustc_demangle=/home/lo48576/works/public/contrib/failure/target/debug/deps/librustc_demangle-52276abf4bd0e9fa.rlib --cap-lints allow
 -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs` (exit code: 1)
warning: build failed, waiting for other jobs to finish...
error: build failed
```

</details>

With `version = "0.3.13"` for `backtrace`:

<details>

```
$ cargo +nightly update -Z minimal-versions && cargo test --all-features --verbose
    Updating crates.io index
       Fresh unicode-xid v0.1.0
       Fresh cc v1.0.0
   Compiling autocfg v0.1.0
   Compiling cfg-if v0.1.6
       Fresh rustc-demangle v0.1.4
       Fresh proc-macro2 v0.4.8
     Running `rustc --crate-name autocfg /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/autocfg-0.1.0/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=3bec8eb4adde6d59 -C extra-filename=-3bec8eb4adde6d59 --out-dir /
home/lo48576/works/public/contrib/failure/target/debug/deps -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name cfg_if /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/cfg-if-0.1.6/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=778a08baeabb17cf -C extra-filename=-778a08baeabb17cf --out-dir /ho
me/lo48576/works/public/contrib/failure/target/debug/deps -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps --cap-lints allow`
       Fresh quote v0.6.3
       Fresh libc v0.2.45
       Fresh syn v0.15.0
       Fresh backtrace-sys v0.1.17
       Fresh synstructure v0.10.0
   Compiling failure_derive v0.1.5 (/home/lo48576/works/public/contrib/failure/failure_derive)
     Running `rustc --crate-name failure_derive failure_derive/src/lib.rs --color always --crate-type proc-macro --emit=dep-info,link -C prefer-dynamic -C debuginfo=2 -C metadata=a0bd02f577b87743 -C extra-filename=-a0bd02f577b87743 --out-dir /home/lo48576/works/public/con
trib/failure/target/debug/deps -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps --extern proc_macro2=/home/lo48576/works/public/contrib/failure/target/debug/deps/l
ibproc_macro2-9efc4637933a1c09.rlib --extern quote=/home/lo48576/works/public/contrib/failure/target/debug/deps/libquote-af3aaac9b3bdf216.rlib --extern syn=/home/lo48576/works/public/contrib/failure/target/debug/deps/libsyn-d11856994fd8305f.rlib --extern synstructure=/hom
e/lo48576/works/public/contrib/failure/target/debug/deps/libsynstructure-7bc10f70af82650c.rlib --cfg has_dyn_trait`
   Compiling backtrace v0.3.13
     Running `rustc --crate-name build_script_build /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.13/build.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 --cfg 'feature="backtrace-sys"' --cfg 'feature="coresymbolicatio
n"' --cfg 'feature="dbghelp"' --cfg 'feature="default"' --cfg 'feature="dladdr"' --cfg 'feature="libbacktrace"' --cfg 'feature="libunwind"' --cfg 'feature="std"' -C metadata=00b626b600ddeaa9 -C extra-filename=-00b626b600ddeaa9 --out-dir /home/lo48576/works/public/contrib/
failure/target/debug/build/backtrace-00b626b600ddeaa9 -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps --extern autocfg=/home/lo48576/works/public/contrib/failure/target/debug/deps/libautocfg-3bec8eb4adde6d59.rlib --cap-lints allow`
     Running `/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-00b626b600ddeaa9/build-script-build`
     Running `rustc --crate-name backtrace /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.13/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 --cfg 'feature="backtrace-sys"' --cfg 'feature="coresymbolication"' --c
fg 'feature="dbghelp"' --cfg 'feature="default"' --cfg 'feature="dladdr"' --cfg 'feature="libbacktrace"' --cfg 'feature="libunwind"' --cfg 'feature="std"' -C metadata=b8a2e79461b1841f -C extra-filename=-b8a2e79461b1841f --out-dir /home/lo48576/works/public/contrib/failure
/target/debug/deps -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps --extern backtrace_sys=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace_sys-b1cf48c04e38413f.rlib --extern cfg_if=/home/lo48576/works/public/contrib/fail
ure/target/debug/deps/libcfg_if-778a08baeabb17cf.rlib --extern libc=/home/lo48576/works/public/contrib/failure/target/debug/deps/liblibc-3b524ef2d6fa4eb7.rlib --extern rustc_demangle=/home/lo48576/works/public/contrib/failure/target/debug/deps/librustc_demangle-52276abf4b
d0e9fa.rlib --cap-lints allow --cfg rustc_1_30 -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
   Compiling failure v0.1.5 (/home/lo48576/works/public/contrib/failure)
     Running `rustc --crate-name failure src/lib.rs --color always --emit=dep-info,link -C debuginfo=2 --test --cfg 'feature="backtrace"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="failure_derive"' --cfg 'feature="std"' -C metadata=2e23376e022f5d78
 -C extra-filename=-2e23376e022f5d78 --out-dir /home/lo48576/works/public/contrib/failure/target/debug/deps -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps --exte
rn backtrace=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure_derive=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure_derive-a0bd02f577b87743.so -L native=/home/lo48576/works/public/con
trib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
     Running `rustc --crate-name failure src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 --cfg 'feature="backtrace"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="failure_derive"' --cfg 'feature="std"' -C metadata=37a135
5e6dfc432e -C extra-filename=-37a1355e6dfc432e --out-dir /home/lo48576/works/public/contrib/failure/target/debug/deps -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/d
eps --extern backtrace=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure_derive=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure_derive-a0bd02f577b87743.so -L native=/home/lo48576/works/
public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
     Running `rustc --crate-name error_as_cause examples/error_as_cause.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 --cfg 'feature="backtrace"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="failure_derive"' --cfg 'feature="s
td"' -C metadata=9c275366ce2fafbf -C extra-filename=-9c275366ce2fafbf --out-dir /home/lo48576/works/public/contrib/failure/target/debug/examples -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/home/lo48576/works/public/con
trib/failure/target/debug/deps --extern backtrace=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure-37a1355e6dfc432e.rlib --extern failur
e_derive=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure_derive-a0bd02f577b87743.so -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
     Running `rustc --crate-name basic_fail tests/basic_fail.rs --color always --emit=dep-info,link -C debuginfo=2 --test --cfg 'feature="backtrace"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="failure_derive"' --cfg 'feature="std"' -C metadata=1071
fd45de85583b -C extra-filename=-1071fd45de85583b --out-dir /home/lo48576/works/public/contrib/failure/target/debug/deps -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/home/lo48576/works/public/contrib/failure/target/debug
/deps --extern backtrace=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure-37a1355e6dfc432e.rlib --extern failure_derive=/home/lo48576/wo
rks/public/contrib/failure/target/debug/deps/libfailure_derive-a0bd02f577b87743.so -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
     Running `rustc --crate-name bail_ensure examples/bail_ensure.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 --cfg 'feature="backtrace"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="failure_derive"' --cfg 'feature="std"' -
C metadata=c22837a85abcdb54 -C extra-filename=-c22837a85abcdb54 --out-dir /home/lo48576/works/public/contrib/failure/target/debug/examples -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/home/lo48576/works/public/contrib/f
ailure/target/debug/deps --extern backtrace=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure-37a1355e6dfc432e.rlib --extern failure_deri
ve=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure_derive-a0bd02f577b87743.so -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
     Running `rustc --crate-name simple examples/simple.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 --cfg 'feature="backtrace"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="failure_derive"' --cfg 'feature="std"' -C metadata
=f786d48e9f38f4df -C extra-filename=-f786d48e9f38f4df --out-dir /home/lo48576/works/public/contrib/failure/target/debug/examples -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/home/lo48576/works/public/contrib/failure/tar
get/debug/deps --extern backtrace=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure-37a1355e6dfc432e.rlib --extern failure_derive=/home/l
o48576/works/public/contrib/failure/target/debug/deps/libfailure_derive-a0bd02f577b87743.so -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
     Running `rustc --crate-name fail_compat tests/fail_compat.rs --color always --emit=dep-info,link -C debuginfo=2 --test --cfg 'feature="backtrace"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="failure_derive"' --cfg 'feature="std"' -C metadata=85
ac7485d86b7bd9 -C extra-filename=-85ac7485d86b7bd9 --out-dir /home/lo48576/works/public/contrib/failure/target/debug/deps -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/home/lo48576/works/public/contrib/failure/target/deb
ug/deps --extern backtrace=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure-37a1355e6dfc432e.rlib --extern failure_derive=/home/lo48576/
works/public/contrib/failure/target/debug/deps/libfailure_derive-a0bd02f577b87743.so -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
     Running `rustc --crate-name macro_trailing_comma tests/macro_trailing_comma.rs --color always --emit=dep-info,link -C debuginfo=2 --test --cfg 'feature="backtrace"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="failure_derive"' --cfg 'feature="st
d"' -C metadata=92804c55f2202c86 -C extra-filename=-92804c55f2202c86 --out-dir /home/lo48576/works/public/contrib/failure/target/debug/deps -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/home/lo48576/works/public/contrib/
failure/target/debug/deps --extern backtrace=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure-37a1355e6dfc432e.rlib --extern failure_der
ive=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure_derive-a0bd02f577b87743.so -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
     Running `rustc --crate-name string_custom_error_pattern examples/string_custom_error_pattern.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 --cfg 'feature="backtrace"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="failure_
derive"' --cfg 'feature="std"' -C metadata=f96b7cfe9fb35fa0 -C extra-filename=-f96b7cfe9fb35fa0 --out-dir /home/lo48576/works/public/contrib/failure/target/debug/examples -C incremental=/home/lo48576/works/public/contrib/failure/target/debug/incremental -L dependency=/hom
e/lo48576/works/public/contrib/failure/target/debug/deps --extern backtrace=/home/lo48576/works/public/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure-37a1355e6df
c432e.rlib --extern failure_derive=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure_derive-a0bd02f577b87743.so -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c0c3d77600/out/.libs`
warning: unused `#[macro_use]` import
 --> examples/error_as_cause.rs:1:1
  |
1 | #[macro_use]
  | ^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

warning: unused `#[macro_use]` import
 --> examples/simple.rs:1:1
  |
1 | #[macro_use]
  | ^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

warning: unused `#[macro_use]` import
 --> tests/fail_compat.rs:1:1
  |
1 | #[macro_use]
  | ^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

warning: unused `#[macro_use]` import
 --> tests/basic_fail.rs:1:1
  |
1 | #[macro_use]
  | ^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

    Finished dev [unoptimized + debuginfo] target(s) in 1.58s
     Running `/home/lo48576/works/public/contrib/failure/target/debug/deps/failure-2e23376e022f5d78`

running 7 tests
test backtrace::internal::tests::always_enabled_if_failure_is_set_to_yes ... ok
test backtrace::internal::tests::follows_general_if_failure_is_not_set ... ok
test context::test_map ... ok
test error::test::assert_error_is_just_data ... ok
test error::test::downcast_can_be_used ... ok
test backtrace::internal::tests::never_enabled_if_failure_is_set_to_no ... ok
test error::test::methods_seem_to_work ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running `/home/lo48576/works/public/contrib/failure/target/debug/deps/basic_fail-1071fd45de85583b`

running 1 test
test test_name ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running `/home/lo48576/works/public/contrib/failure/target/debug/deps/fail_compat-85ac7485d86b7bd9`

running 2 tests
test smoke_compat_send_sync ... ok
test smoke_default_compat ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running `/home/lo48576/works/public/contrib/failure/target/debug/deps/macro_trailing_comma-92804c55f2202c86`

running 4 tests
test bail ... ok
test ensure ... ok
test format_err ... ok
test single_arg_ensure ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests failure
     Running `rustdoc --test /home/lo48576/works/public/contrib/failure/src/lib.rs --crate-name failure -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps -L native=/home/lo48576/works/public/contrib/failure/target/debug/build/backtrace-sys-5789c2c
0c3d77600/out/.libs -L dependency=/home/lo48576/works/public/contrib/failure/target/debug/deps --cfg 'feature="failure_derive"' --cfg 'feature="std"' --cfg 'feature="backtrace"' --cfg 'feature="derive"' --cfg 'feature="default"' --extern backtrace=/home/lo48576/works/publ
ic/contrib/failure/target/debug/deps/libbacktrace-b8a2e79461b1841f.rlib --extern failure=/home/lo48576/works/public/contrib/failure/target/debug/deps/libfailure-37a1355e6dfc432e.rlib --extern failure_derive=/home/lo48576/works/public/contrib/failure/target/debug/deps/libf
ailure_derive-a0bd02f577b87743.so`

running 7 tests
test src/macros.rs - bail (line 6) ... ignored
test src/error/mod.rs - error::Error::from_boxed_compat (line 49) ... ok
test src/macros.rs - format_err (line 53) ... ok
test src/sync_failure.rs - sync_failure::SyncFailure<E>::new (line 25) ... ok
test src/result_ext.rs - result_ext::ResultExt::context (line 67) ... ok
test src/result_ext.rs - result_ext::ResultExt::compat (line 12) ... ok
test src/result_ext.rs - result_ext::ResultExt::with_context (line 110) ... ok

test result: ok. 6 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```
</details>