### PR TITLE
Made the simple example even simpler since the error as cause example…

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,22 +1,10 @@
-#[macro_use]
-extern crate failure;
-
 use failure::Fail;
 
 #[derive(Debug, Fail)]
-#[fail(display = "my error")]
+#[fail(display = "Hello World")]
 struct MyError;
 
-#[derive(Debug, Fail)]
-#[fail(display = "my wrapping error")]
-struct WrappingError(#[fail(cause)] MyError);
-
-fn bad_function() -> Result<(), WrappingError> {
-    Err(WrappingError(MyError))
-}
-
 fn main() {
-    for cause in Fail::iter_chain(&bad_function().unwrap_err()) {
-        println!("{}: {}", cause.name().unwrap_or("Error"), cause);
-    }
+    let err: Result<(), MyError> = Err(MyError);
+    println!("{}", err.unwrap_err());
 }


### PR DESCRIPTION
… already shows chaining

I actually had difficulty understanding why the simple example printed the other error, I hope the EVEN SIMPLER example should help people get started