### PR TITLE
Allow failures on nightly because it's not always stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ script:
   - cargo test
   - cargo test --features backtrace
   - cargo check --no-default-features
+matrix:
+  allow_failures:
+  - rust: nightly # because sometimes nightly does weird things and breaks the build

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![allow(bare_trait_objects)] // Allowed so we have compatibility with Rust < 1.27
+
+// So we can have bare_trait_objects lint on Rust versions without it
+#![allow(unknown_lints)]
+// Allowed so we have compatibility with Rust < 1.27
+#![allow(bare_trait_objects)]
+
 #![cfg_attr(feature = "small-error", feature(extern_types, allocator_api))]
 
 macro_rules! with_std { ($($i:item)*) => ($(#[cfg(feature = "std")]$i)*) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(bare_trait_objects)] // Allowed so we have compatibility with Rust < 1.27
 #![cfg_attr(feature = "small-error", feature(extern_types, allocator_api))]
 
 macro_rules! with_std { ($($i:item)*) => ($(#[cfg(feature = "std")]$i)*) }


### PR DESCRIPTION
This fixes the build failure seen in https://github.com/rust-lang-nursery/failure/pull/300 (and will probably show up in master if it got rebuilt again now)