### PR TITLE
fix soudness hole, dependency on unstable layouts

### DIFF
--- a/src/error/error_impl_small.rs
+++ b/src/error/error_impl_small.rs
@@ -10,6 +10,7 @@ pub(crate) struct ErrorImpl {
     inner: &'static mut Inner,
 }
 
+#[repr(C)]
 // Dynamically sized inner value
 struct Inner {
     backtrace: Backtrace,
@@ -25,18 +26,21 @@ extern {
     type FailData;
 }
 
+#[repr(C)]
 #[allow(dead_code)]
 struct InnerRaw<F> {
     header: InnerHeader,
     failure: F,
 }
 
+#[repr(C)]
 #[allow(dead_code)]
 struct InnerHeader {
     backtrace: Backtrace,
     vtable: *const VTable,
 }
 
+#[repr(C)]
 struct TraitObject {
     #[allow(dead_code)]
     data: *const FailData,


### PR DESCRIPTION
The layouts of `repr(Rust)` types are unstable, so you will need to specify a layout to safely depend on them.

Using `repr(C)` is a fine default until we get simething like `repr(linear)`