### PR TITLE
Replace std::error::Error with core_error::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,15 @@ path = "./failure_derive"
 optional = true
 version = "0.3.3"
 
+[dependencies.core-error]
+version = "0.0.1-rc2"
+
 [workspace]
 members = [".", "failure_derive"]
 
 [features]
 default = ["std", "derive"]
 #small-error = ["std"]
-std = ["backtrace"]
+std = ["backtrace", "alloc", "core-error/std"]
+alloc = ["core-error/alloc"]
 derive = ["failure_derive"]

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ If either crate fails to compile on any version newer than 1.31.0, please open
 an issue.
 
 failure is **no_std** compatible, though some aspects of it (primarily the
-`Error` type) will not be available in no_std mode.
+`Error` type) will not be available in no_std mode. Additionally, uses of the
+`std::error::Error` trait (such as in the `Compat` struct) are replaced with
+the [core_error] trait to be compatible with other error handling crates.
 
 ## License
 

--- a/src/box_std.rs
+++ b/src/box_std.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use core_error::Error;
 use std::fmt;
 use Fail;
 

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,4 +1,5 @@
-use core::fmt::{self, Display};
+use core::fmt::{self, Display, Debug};
+use core_error::Error as StdError;
 
 /// A compatibility wrapper around an error type from this crate.
 ///
@@ -27,17 +28,11 @@ impl<E> Compat<E> {
     }
 }
 
+impl<E: Display + Debug> StdError for Compat<E> {}
+
 with_std! {
-    use std::fmt::Debug;
-    use std::error::Error as StdError;
 
     use Error;
-
-    impl<E: Display + Debug> StdError for Compat<E> {
-        fn description(&self) -> &'static str {
-            "An error has occurred."
-        }
-    }
 
     impl From<Error> for Box<dyn StdError> {
         fn from(error: Error) -> Box<dyn StdError> {

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -5,6 +5,8 @@ use core_error::Error as StdError;
 ///
 /// `Compat` implements `std::error::Error`, allowing the types from this
 /// crate to be passed to interfaces that expect a type of that trait.
+///
+/// In `no_std`, `Compat` implements `core_error::Error`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
 pub struct Compat<E> {
     pub(crate) error: E,

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -12,8 +12,7 @@ use box_std::BoxStd;
 mod error_impl;
 use self::error_impl::ErrorImpl;
 
-#[cfg(feature = "std")]
-use std::error::Error as StdError;
+use core_error::Error as StdError;
 
 
 /// The `Error` type, which can contain any failure.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ macro_rules! without_std { ($($i:item)*) => ($(#[cfg(not(feature = "std"))]$i)*)
 #[doc(hidden)]
 pub extern crate core as _core;
 
+extern crate core_error;
+
 mod as_fail;
 mod backtrace;
 #[cfg(feature = "std")]
@@ -59,6 +61,8 @@ extern crate failure_derive;
 #[doc(hidden)]
 pub use failure_derive::*;
 
+use core_error::Error as StdError;
+
 with_std! {
     extern crate core;
 
@@ -66,8 +70,6 @@ with_std! {
     pub use sync_failure::SyncFailure;
 
     mod error;
-
-    use std::error::Error as StdError;
 
     pub use error::Error;
 
@@ -269,7 +271,6 @@ impl dyn Fail {
     }
 }
 
-#[cfg(feature = "std")]
 impl<E: StdError + Send + Sync + 'static> Fail for E {}
 
 #[cfg(feature = "std")]

--- a/src/sync_failure.rs
+++ b/src/sync_failure.rs
@@ -1,5 +1,5 @@
 use Fail;
-use std::error::Error;
+use core_error::Error;
 use std::fmt::{self, Debug, Display};
 use std::sync::Mutex;
 


### PR DESCRIPTION
Fixes #328 

Use `core_error::Error`, a compatibility Error trait in `no_std` environment allowing interoperability between various error handling crates, such as snafu. In std environment, `core_error` simply reexports `std::error`, so this change should be invisible to std users.

In particular this change does two things:

- It implements `Fail` on every `core_error::Error` error.
- It implements `core_error::Error` on `Compat`.

It also replaces other usage of `std::error::Error` to `core_error::Error`, but those should have no visible effect.

This is a preliminary PR to get some feedback. In particular, I'm not sure where to document the changes. no_std documentation is pretty scarce in failure. 