### PR TITLE
Prepare 0.1.7 Release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ homepage = "https://rust-lang-nursery.github.io/failure/"
 license = "MIT OR Apache-2.0"
 name = "failure"
 repository = "https://github.com/rust-lang-nursery/failure"
-version = "0.1.6"
+version = "0.1.7"
 
 [dependencies.failure_derive]
 optional = true
-version = "0.1.6"
+version = "0.1.7"
 path = "./failure_derive"
 
 [dependencies.backtrace]

--- a/failure_derive/Cargo.toml
+++ b/failure_derive/Cargo.toml
@@ -3,10 +3,10 @@ authors = ["Without Boats <woboats@gmail.com>"]
 description = "derives for the failure crate"
 license = "MIT OR Apache-2.0"
 name = "failure_derive"
-repository = "https://github.com/withoutboats/failure_derive"
+repository = "https://github.com/rust-lang-nursery/failure"
 homepage = "https://rust-lang-nursery.github.io/failure/"
 documentation = "https://docs.rs/failure"
-version = "0.1.6"
+version = "0.1.7"
 build = "build.rs"
 
 [dependencies]
@@ -16,7 +16,7 @@ synstructure = "0.12.0"
 proc-macro2 = "1"
 
 [dev-dependencies.failure]
-version = "0.1.0"
+version = "0.1.7"
 path = ".."
 
 [lib]


### PR DESCRIPTION
This PR prepares a release containing changes from:

- https://github.com/rust-lang-nursery/failure/pull/343, which resolves https://github.com/rust-lang-nursery/failure/issues/342.
- https://github.com/rust-lang-nursery/failure/pull/344