### PR TITLE
Unblock Crates.io Publishing

### DIFF
--- a/failure_derive/Cargo.toml
+++ b/failure_derive/Cargo.toml
@@ -16,7 +16,7 @@ synstructure = "0.12.0"
 proc-macro2 = "1"
 
 [dev-dependencies.failure]
-version = "0.1.7"
+version = "0.1.0"
 path = ".."
 
 [lib]


### PR DESCRIPTION
In https://github.com/rust-lang-nursery/failure/pull/345, I've changed failure-derive's dev-dependency on failure to 0.1.7. This caused a circular dependency that left me unable to publish the changes. This PR fixes that issue.